### PR TITLE
Kithe::Model asset representative

### DIFF
--- a/app/models/kithe/asset.rb
+++ b/app/models/kithe/asset.rb
@@ -2,7 +2,7 @@ class Kithe::Asset < Kithe::Model
   has_many :derivatives, foreign_key: "asset_id", inverse_of: "asset", dependent: :destroy # dependent destroy to get shrine destroy logic for assets
 
   # representatives don't apply to assets, they are their own
-  self.ignored_columns = %w(representative_id)
+  self.ignored_columns = %w(representative_id leaf_representative_id)
 
   # TODO we may need a way for local app to provide custom uploader class.
   # or just override at ./kithe/asset_uploader.rb locally?
@@ -197,9 +197,11 @@ class Kithe::Asset < Kithe::Model
   def representative
     self
   end
+  alias_method :leaf_representative, :representative
   def representative_id
     id
   end
+  alias_method :leaf_representative_id, :representative_id
 
   private
 

--- a/app/models/kithe/asset.rb
+++ b/app/models/kithe/asset.rb
@@ -1,8 +1,12 @@
 class Kithe::Asset < Kithe::Model
   has_many :derivatives, foreign_key: "asset_id", inverse_of: "asset", dependent: :destroy # dependent destroy to get shrine destroy logic for assets
 
-  # representatives don't apply to assets, they are their own
+  # These associations exist for hetereogenous eager-loading, but hide em.
+  # They are defined as self-pointing below.
   self.ignored_columns = %w(representative_id leaf_representative_id)
+  belongs_to :representative, -> { none }, class_name: "Kithe::Model"
+  belongs_to :leaf_representative, -> { none }, class_name: "Kithe::Model"
+  private :representative, :representative=, :leaf_representative, :leaf_representative=
 
   # TODO we may need a way for local app to provide custom uploader class.
   # or just override at ./kithe/asset_uploader.rb locally?

--- a/app/models/kithe/asset.rb
+++ b/app/models/kithe/asset.rb
@@ -1,6 +1,8 @@
 class Kithe::Asset < Kithe::Model
-  # This only applies to assets, but we put it here so we can pre-load it on members fetch. :(
   has_many :derivatives, foreign_key: "asset_id", inverse_of: "asset", dependent: :destroy # dependent destroy to get shrine destroy logic for assets
+
+  # representatives don't apply to assets, they are their own
+  self.ignored_columns = %w(representative_id)
 
   # TODO we may need a way for local app to provide custom uploader class.
   # or just override at ./kithe/asset_uploader.rb locally?
@@ -189,6 +191,14 @@ class Kithe::Asset < Kithe::Model
     saved_change_to_file_data? &&
       saved_change_to_file_data.first.try(:dig, "metadata", "sha512") !=
         saved_change_to_file_data.second.try(:dig, "metadata", "sha512")
+  end
+
+  # An Asset is it's own representative
+  def representative
+    self
+  end
+  def representative_id
+    id
   end
 
   private

--- a/app/models/kithe/model.rb
+++ b/app/models/kithe/model.rb
@@ -13,10 +13,14 @@ class Kithe::Model < ActiveRecord::Base
   # when fetching all Kithe::Model. And it's to Kithe::Model so it can include
   # both Works and Assets. We do some app-level validation to try and make it used
   # as intended.
-  #
-  # TODO: what should 'dependent' be?
   has_many :members, class_name: "Kithe::Model", foreign_key: :parent_id, inverse_of: :parent, dependent: :destroy
   belongs_to :parent, class_name: "Kithe::Model", inverse_of: :members, optional: true
+
+
+  # Mainly meant for Works (maybe Collection too?), but on Kithe::Model to allow rails eager
+  # loading on hetereogenous fetches
+  belongs_to :representative, class_name: "Kithe::Model", foreign_key: :representative_id, optional: true
+
 
   # recovering a bit from our generalized members/parent relationship with validations.
   # parent has to be a Work, and Collections don't have parents (for now?), etc.

--- a/db/migrate/20190103144947_add_representative_relations.rb
+++ b/db/migrate/20190103144947_add_representative_relations.rb
@@ -1,5 +1,6 @@
 class AddRepresentativeRelations < ActiveRecord::Migration[5.2]
   def change
     add_reference :kithe_models, :representative, foreign_key: {to_table: :kithe_models}, type: :uuid, null: true
+    add_reference :kithe_models, :leaf_representative, foreign_key: {to_table: :kithe_models}, type: :uuid, null: true
   end
 end

--- a/db/migrate/20190103144947_add_representative_relations.rb
+++ b/db/migrate/20190103144947_add_representative_relations.rb
@@ -1,0 +1,5 @@
+class AddRepresentativeRelations < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :kithe_models, :representative, foreign_key: {to_table: :kithe_models}, type: :uuid, null: true
+  end
+end

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -143,7 +143,8 @@ CREATE TABLE kithe_models (
     updated_at timestamp without time zone NOT NULL,
     parent_id uuid,
     friendlier_id character varying DEFAULT kithe_models_friendlier_id_gen('2821109907456'::bigint, '101559956668415'::bigint) NOT NULL,
-    file_data jsonb
+    file_data jsonb,
+    representative_id uuid
 );
 
 
@@ -224,6 +225,13 @@ CREATE INDEX index_kithe_models_on_parent_id ON kithe_models USING btree (parent
 
 
 --
+-- Name: index_kithe_models_on_representative_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_kithe_models_on_representative_id ON kithe_models USING btree (representative_id);
+
+
+--
 -- Name: kithe_derivatives fk_rails_3dac8b4201; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -240,6 +248,14 @@ ALTER TABLE ONLY kithe_models
 
 
 --
+-- Name: kithe_models fk_rails_afa93b7b5d; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY kithe_models
+    ADD CONSTRAINT fk_rails_afa93b7b5d FOREIGN KEY (representative_id) REFERENCES kithe_models(id);
+
+
+--
 -- PostgreSQL database dump complete
 --
 
@@ -250,6 +266,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20181015143413'),
 ('20181015143737'),
 ('20181031190647'),
-('20181128185658');
+('20181128185658'),
+('20190103144947');
 
 

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -144,7 +144,8 @@ CREATE TABLE kithe_models (
     parent_id uuid,
     friendlier_id character varying DEFAULT kithe_models_friendlier_id_gen('2821109907456'::bigint, '101559956668415'::bigint) NOT NULL,
     file_data jsonb,
-    representative_id uuid
+    representative_id uuid,
+    leaf_representative_id uuid
 );
 
 
@@ -218,6 +219,13 @@ CREATE UNIQUE INDEX index_kithe_models_on_friendlier_id ON kithe_models USING bt
 
 
 --
+-- Name: index_kithe_models_on_leaf_representative_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_kithe_models_on_leaf_representative_id ON kithe_models USING btree (leaf_representative_id);
+
+
+--
 -- Name: index_kithe_models_on_parent_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -237,6 +245,14 @@ CREATE INDEX index_kithe_models_on_representative_id ON kithe_models USING btree
 
 ALTER TABLE ONLY kithe_derivatives
     ADD CONSTRAINT fk_rails_3dac8b4201 FOREIGN KEY (asset_id) REFERENCES kithe_models(id);
+
+
+--
+-- Name: kithe_models fk_rails_403cce5c0d; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY kithe_models
+    ADD CONSTRAINT fk_rails_403cce5c0d FOREIGN KEY (leaf_representative_id) REFERENCES kithe_models(id);
 
 
 --

--- a/spec/models/kithe/representatives_spec.rb
+++ b/spec/models/kithe/representatives_spec.rb
@@ -84,5 +84,19 @@ RSpec.describe "Model representatives", type: :model do
         expect(great_grandparent2.reload.leaf_representative_id).to eq(asset2.id)
       end
     end
+
+    describe "hetereogenous fetch" do
+      let!(:asset) { FactoryBot.create(:kithe_asset) }
+      let!(:work) { FactoryBot.create(:kithe_work, representative: asset) }
+      let!(:collection) { FactoryBot.create(:kithe_collection, representative: work) }
+
+      it "can eager load" do
+        all = Kithe::Model.includes(:leaf_representative).all.to_a
+        all.each do |model|
+          expect(model.association(:leaf_representative).loaded?).to be(true)
+          expect(model.leaf_representative).to eq(asset)
+        end
+      end
+    end
   end
 end

--- a/spec/models/kithe/representatives_spec.rb
+++ b/spec/models/kithe/representatives_spec.rb
@@ -20,4 +20,33 @@ RSpec.describe "Model representatives", type: :model do
       expect(asset.representative_id).to eq(asset.id)
     end
   end
+
+  describe "leaf_representative" do
+    let(:work) { FactoryBot.create(:kithe_work, title: "top", representative: intermediate_work)}
+    let(:intermediate_work) { FactoryBot.create(:kithe_work, title: "intermediate", representative: asset)}
+
+    it "is set" do
+      expect(intermediate_work.leaf_representative).to eq(asset)
+      expect(work.leaf_representative).to eq(asset)
+
+      work.representative = nil
+      work.save!
+      expect(work.leaf_representative).to be(nil)
+    end
+
+    describe "with accidental cycle" do
+      let(:work) { FactoryBot.create(:kithe_work) }
+      let(:work2) { FactoryBot.create(:kithe_work) }
+
+      it "handles sanely" do
+        work.update(representative_id: work2.id)
+        work2.update(representative_id: work.id)
+
+        # mainly we care that it didn't infinite loop or raise, don't care
+        # too much what it is, it's a mess.
+        expect(work.leaf_representative_id).to eq(work.representative_id)
+        expect(work2.leaf_representative_id).to eq(work2.id)
+      end
+    end
+  end
 end

--- a/spec/models/kithe/representatives_spec.rb
+++ b/spec/models/kithe/representatives_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+
+RSpec.describe "Model representatives", type: :model do
+  let(:work) { FactoryBot.create(:kithe_work) }
+  let(:asset) { FactoryBot.create(:kithe_asset) }
+
+  it "can assign" do
+    work.representative = asset
+    work.save!
+    work.reload
+
+    expect(work.representative_id).to eq(asset.id)
+    expect(work.representative).to eq(asset)
+  end
+
+  describe "on an asset" do
+    it "is it's own representative" do
+      expect(asset.representative).to eq(asset)
+      expect(asset.representative_id).to eq(asset.id)
+    end
+  end
+end


### PR DESCRIPTION
A Work can have an asset or another work set as representative. leaf_representative is set to an asset after following the chain, using rails callbacks with very efficient one-query SQL using postgres recursive CTEs. (Collection can have representative too, although not sure if that's useful or how to use it at present).  

An Asset has methods for representative and leaf_representative returning itself. Hetereogenous selects with eager load of leaf_representative work.