### PR TITLE
Promotion directives improvements

### DIFF
--- a/app/jobs/kithe/create_derivatives_job.rb
+++ b/app/jobs/kithe/create_derivatives_job.rb
@@ -1,0 +1,7 @@
+module Kithe
+  class CreateDerivativesJob < Job
+    def perform(asset, mark_created: true)
+      asset.create_derivatives(mark_created: mark_created)
+    end
+  end
+end

--- a/app/models/kithe/asset.rb
+++ b/app/models/kithe/asset.rb
@@ -29,8 +29,11 @@ class Kithe::Asset < Kithe::Model
   define_model_callbacks :promotion
 
   after_promotion do
-    byebug
-    unless file_attacher.promotion_directives[:create_derivatives] == false
+    if file_attacher.promotion_directives[:create_derivatives] == false
+      # no-op
+    elsif file_attacher.promotion_directives[:create_derivatives].to_s == "foreground"
+      Kithe::CreateDerivativesJob.perform_now(self, mark_created: true)
+    else
       Kithe::CreateDerivativesJob.perform_later(self, mark_created: true)
     end
   end

--- a/app/models/kithe/asset.rb
+++ b/app/models/kithe/asset.rb
@@ -31,7 +31,7 @@ class Kithe::Asset < Kithe::Model
   after_promotion do
     if file_attacher.promotion_directives[:create_derivatives] == false
       # no-op
-    elsif file_attacher.promotion_directives[:create_derivatives].to_s == "foreground"
+    elsif file_attacher.promotion_directives[:create_derivatives].to_s == "inline"
       Kithe::CreateDerivativesJob.perform_now(self, mark_created: true)
     else
       Kithe::CreateDerivativesJob.perform_later(self, mark_created: true)

--- a/app/models/kithe/asset.rb
+++ b/app/models/kithe/asset.rb
@@ -29,7 +29,7 @@ class Kithe::Asset < Kithe::Model
   define_model_callbacks :promotion
 
   after_promotion do
-    self.create_derivatives(mark_created: true)
+    Kithe::CreateDerivativesJob.perform_later(self, mark_created: true)
   end
 
   # Establish a derivative definition that will be used to create a derivative

--- a/app/models/kithe/asset.rb
+++ b/app/models/kithe/asset.rb
@@ -29,7 +29,10 @@ class Kithe::Asset < Kithe::Model
   define_model_callbacks :promotion
 
   after_promotion do
-    Kithe::CreateDerivativesJob.perform_later(self, mark_created: true)
+    byebug
+    unless file_attacher.promotion_directives[:create_derivatives] == false
+      Kithe::CreateDerivativesJob.perform_later(self, mark_created: true)
+    end
   end
 
   # Establish a derivative definition that will be used to create a derivative

--- a/app/uploaders/kithe/asset_uploader.rb
+++ b/app/uploaders/kithe/asset_uploader.rb
@@ -37,11 +37,11 @@ module Kithe
     # Normally we promote in background with backgrounding, but the set_promotion_directives
     # feature can be used to make promotion not happen at all, or happen in foreground.
     #     asset.file_attacher.set_promotion_directives(promote: "none")
-    #     asset.file_attacher.set_promotion_directives(promote: "foreground")
+    #     asset.file_attacher.set_promotion_directives(promote: "inline")
     Attacher.promote do |data|
       if data && data.dig("promotion_directives", :promote).to_s == "none"
         # no op
-      elsif data && data.dig("promotion_directives", :promote).to_s == "foreground"
+      elsif data && data.dig("promotion_directives", :promote).to_s == "inline"
         # Foreground, but you'll still need to #reload your asset to see changes,
         # since backgrounding mechanism still reloads a new instance, sorry.
         #Kithe::AssetPromoteJob.perform_now(data)

--- a/spec/models/kithe/asset/asset_promotion_hooks_spec.rb
+++ b/spec/models/kithe/asset/asset_promotion_hooks_spec.rb
@@ -107,7 +107,7 @@ describe "Kithe::Asset promotion hooks", queue_adapter: :inline do
     end
 
     it "can force promotion in foreground" do
-      unsaved_asset.file_attacher.set_promotion_directives(promote: :foreground)
+      unsaved_asset.file_attacher.set_promotion_directives(promote: :inline)
 
       unsaved_asset.save!
       unsaved_asset.reload
@@ -122,7 +122,7 @@ describe "Kithe::Asset promotion hooks", queue_adapter: :inline do
       it "does not create derivatives" do
         expect_any_instance_of(Kithe::Asset).not_to receive(:create_derivatives)
 
-        unsaved_asset.file_attacher.set_promotion_directives(promote: :foreground, create_derivatives: false)
+        unsaved_asset.file_attacher.set_promotion_directives(promote: :inline, create_derivatives: false)
 
         unsaved_asset.save!
         unsaved_asset.reload
@@ -133,11 +133,11 @@ describe "Kithe::Asset promotion hooks", queue_adapter: :inline do
       end
     end
 
-    describe ", create_derivatives: :foreground" do
+    describe ", create_derivatives: :inline" do
       it "creates derivatives inline" do
         expect_any_instance_of(Kithe::Asset).to receive(:create_derivatives)
 
-        unsaved_asset.file_attacher.set_promotion_directives(promote: :foreground, create_derivatives: :foreground)
+        unsaved_asset.file_attacher.set_promotion_directives(promote: :inline, create_derivatives: :inline)
 
         unsaved_asset.save!
         unsaved_asset.reload

--- a/spec/models/kithe/asset/asset_promotion_hooks_spec.rb
+++ b/spec/models/kithe/asset/asset_promotion_hooks_spec.rb
@@ -120,7 +120,24 @@ describe "Kithe::Asset promotion hooks", queue_adapter: :inline do
 
     describe ", create_derivatives: false" do
       it "does not create derivatives" do
+        expect_any_instance_of(Kithe::Asset).not_to receive(:create_derivatives)
+
         unsaved_asset.file_attacher.set_promotion_directives(promote: :foreground, create_derivatives: false)
+
+        unsaved_asset.save!
+        unsaved_asset.reload
+
+        expect(Kithe::AssetPromoteJob).not_to have_been_enqueued
+        expect(Kithe::CreateDerivativesJob).not_to have_been_enqueued
+        expect(ActiveJob::Base.queue_adapter.performed_jobs.size).to eq(0)
+      end
+    end
+
+    describe ", create_derivatives: :foreground" do
+      it "creates derivatives inline" do
+        expect_any_instance_of(Kithe::Asset).to receive(:create_derivatives)
+
+        unsaved_asset.file_attacher.set_promotion_directives(promote: :foreground, create_derivatives: :foreground)
 
         unsaved_asset.save!
         unsaved_asset.reload

--- a/spec/models/kithe/asset/asset_promotion_hooks_spec.rb
+++ b/spec/models/kithe/asset/asset_promotion_hooks_spec.rb
@@ -114,8 +114,23 @@ describe "Kithe::Asset promotion hooks", queue_adapter: :inline do
 
       expect(unsaved_asset.stored?).to be(true)
       expect(Kithe::AssetPromoteJob).not_to have_been_enqueued
+      expect(Kithe::CreateDerivativesJob).to have_been_enqueued
       expect(ActiveJob::Base.queue_adapter.performed_jobs.size).to eq(0)
     end
+
+    describe ", create_derivatives: false" do
+      it "does not create derivatives" do
+        unsaved_asset.file_attacher.set_promotion_directives(promote: :foreground, create_derivatives: false)
+
+        unsaved_asset.save!
+        unsaved_asset.reload
+
+        expect(Kithe::AssetPromoteJob).not_to have_been_enqueued
+        expect(Kithe::CreateDerivativesJob).not_to have_been_enqueued
+        expect(ActiveJob::Base.queue_adapter.performed_jobs.size).to eq(0)
+      end
+    end
   end
+
 
 end

--- a/spec/models/kithe/asset/asset_promotion_hooks_spec.rb
+++ b/spec/models/kithe/asset/asset_promotion_hooks_spec.rb
@@ -113,7 +113,7 @@ describe "Kithe::Asset promotion hooks", queue_adapter: :inline do
       unsaved_asset.reload
 
       expect(unsaved_asset.stored?).to be(true)
-      expect(ActiveJob::Base.queue_adapter.enqueued_jobs.size).to eq(0)
+      expect(Kithe::AssetPromoteJob).not_to have_been_enqueued
       expect(ActiveJob::Base.queue_adapter.performed_jobs.size).to eq(0)
     end
   end


### PR DESCRIPTION
* derivatives are in a _separate_ job by default, but can be controllled by promotion_directive create_derivatives false or :inline
* promotion_directive[promote] value changed from 'foreground' to inline

These interact in odd ways. Promote inline will still by default send off a separate job for derivatives. 

This stuff is weird, but I haven't seen a great model for controlling foreground/backgrounding of a multi-job bg process like this. This is a try at something.