### PR TITLE
Add a more convenient kithe:create_derivatives:lazy_defaults task

### DIFF
--- a/lib/kithe.rb
+++ b/lib/kithe.rb
@@ -1,6 +1,9 @@
 require "kithe/engine"
 
 module Kithe
+  # for ruby-progressbar
+  STANDARD_PROGRESS_BAR_FORMAT = "%a %t: |%B| %R/s %c/%u %p%% %e"
+
   # ActiveRecord will automatically pick this up for all our models.
   # We don't want an isolated engine, but we do want this, part of what isolated engines do.
   def self.table_name_prefix


### PR DESCRIPTION
I think this is still slower than it should be, we should probably perf profile at some point, first let's see how long it actually takes at scale.