### PR TITLE
Better derivative filename in shrine metadata

### DIFF
--- a/app/models/kithe/asset/derivative_updater.rb
+++ b/app/models/kithe/asset/derivative_updater.rb
@@ -48,7 +48,10 @@ class Kithe::Asset::DerivativeUpdater
 
     # skip cache phase, right to specified storage, but with metadata extraction.
     uploader = deriv.file_attacher.shrine_class.new(storage_key)
-    uploaded_file = uploader.upload(io, record: deriv, metadata: metadata)
+
+    # add our derivative key to context when uploading, so Kithe::DerivativeUploader can
+    # use it if needed.
+    uploaded_file = uploader.upload(io, record: deriv, metadata: metadata.merge(kithe_derivative_key: key))
 
     optimistically_save_derivative(uploaded_file: uploaded_file, derivative: deriv)
   end

--- a/app/uploaders/kithe/derivative_uploader.rb
+++ b/app/uploaders/kithe/derivative_uploader.rb
@@ -1,3 +1,5 @@
+require 'mini_mime'
+
 module Kithe
   # The derivative uploader doesn't have to do too much, we don't even use
   # promotion for derivatives, just writing directly to a storage.
@@ -9,7 +11,6 @@ module Kithe
     plugin :determine_mime_type, analyzer: :marcel
     plugin :store_dimensions
 
-
     # should this be in a plugin? location in file system based on original asset
     # id and derivative key, as well as unique random file id from shrine.
     def generate_location(io, context)
@@ -18,6 +19,22 @@ module Kithe
       key = context[:record].key
       original = super
       [asset_id, key, original].compact.join("/")
+    end
+
+
+    # Override to fix "filename" metadata to be something reasonable, regardless
+    # of what if anything was the filename of the IO being attached. shrine S3 will
+    # insist on setting a default content-disposition with this filename.
+    def extract_metadata(io, context = {})
+      result = super
+
+      if context.dig(:metadata, :kithe_derivative_key) &&
+         context[:record]
+        extension = MiniMime.lookup_by_content_type(result["mime_type"] || "")&.extension
+        result["filename"] = "#{context[:record].asset.friendlier_id}_#{context[:metadata][:kithe_derivative_key]}.#{extension}"
+      end
+
+      return result
     end
   end
 end

--- a/kithe.gemspec
+++ b/kithe.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency "pdf-reader", "~> 2.0" # for pdf metadata extraction
   s.add_dependency "tty-command", ">= 0.8.2", "< 2" # still at pre-1.0 when we write this. :(
   s.add_dependency "ruby-progressbar", "~> 1.0"
+  s.add_dependency "mini_mime" # already a rails dependency, but we use in derivative filename construction
 
   s.add_development_dependency "pg"
   s.add_development_dependency "yard-activesupport-concern"

--- a/spec/models/kithe/derivative_spec.rb
+++ b/spec/models/kithe/derivative_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe Kithe::Derivative, type: :model, queue_adapter: :test do
       expect(derivative.content_type).to eq("image/jpeg")
       expect(derivative.height).to eq(1)
       expect(derivative.width).to eq(1)
+      expect(derivative.file.metadata["filename"]).to eq("#{asset.friendlier_id}_some_derivative.jpeg")
 
       # path on storage is nice and pretty
       expect(derivative.file.id).to match %r{\A#{asset.id}/#{key}/[a-f0-9]+\.jpg\Z}


### PR DESCRIPTION
Shrine S3 uses it to set a content-disposition, so let's make it present and reasonable.