### PR TITLE
Make kithe_model_type more resilient

### DIFF
--- a/app/models/kithe/asset.rb
+++ b/app/models/kithe/asset.rb
@@ -11,6 +11,10 @@ class Kithe::Asset < Kithe::Model
   after_initialize do
     self.kithe_model_type = "asset" if self.kithe_model_type.nil?
   end
+  before_validation do
+    self.kithe_model_type = "asset" if self.kithe_model_type.nil?
+  end
+
 
   # TODO we may need a way for local app to provide custom uploader class.
   # or just override at ./kithe/asset_uploader.rb locally?

--- a/app/models/kithe/collection.rb
+++ b/app/models/kithe/collection.rb
@@ -7,4 +7,8 @@ class Kithe::Collection < Kithe::Model
   after_initialize do
     self.kithe_model_type = "collection" if self.kithe_model_type.nil?
   end
+  before_validation do
+    self.kithe_model_type = "collection" if self.kithe_model_type.nil?
+  end
+
 end

--- a/app/models/kithe/work.rb
+++ b/app/models/kithe/work.rb
@@ -7,4 +7,8 @@ class Kithe::Work < Kithe::Model
   after_initialize do
     self.kithe_model_type = "work" if self.kithe_model_type.nil?
   end
+  before_validation do
+    self.kithe_model_type = "work" if self.kithe_model_type.nil?
+  end
+
 end


### PR DESCRIPTION
As a result of #43, we have a required kithe_model_type column. We were making sure it was set in an initialize callback, but make sure it's set in a before_validation callback too, in case someone accidentally deleted it. We actually did in our app. Hmm, this feature is a bit fragile, but I think it's worth it.