### PR TITLE
Kithe::Indexer lets you customize what field to send to Solr id

### DIFF
--- a/app/indexing/kithe/indexable.rb
+++ b/app/indexing/kithe/indexable.rb
@@ -53,12 +53,15 @@ module Kithe
     extend ActiveSupport::Concern
 
     class IndexableSettings
-      attr_accessor :solr_url, :writer_class_name, :writer_settings, :model_name_solr_field, :disable_callbacks
-      def initialize(solr_url:, writer_class_name:, writer_settings:, model_name_solr_field:, disable_callbacks: false)
+      attr_accessor :solr_url, :writer_class_name, :writer_settings,
+                    :model_name_solr_field, :solr_id_value_attribute, :disable_callbacks
+      def initialize(solr_url:, writer_class_name:, writer_settings:,
+                     model_name_solr_field:, solr_id_value_attribute:, disable_callbacks: false)
         @solr_url = solr_url
         @writer_class_name = writer_class_name
         @writer_settings = writer_settings
         @model_name_solr_field = model_name_solr_field
+        @solr_id_value_attribute = solr_id_value_attribute
       end
 
       # Use configured solr_url, and merge together with configured
@@ -94,6 +97,9 @@ module Kithe
     #
     #     Kithe::Indexable.settings.model_name_solr_field = "my_model_name_field"
     #
+    # * solr_id_value_attribute: What attribute from your AR models to send to Solr
+    #   `id` uniqueKey field, default the AR `id` pk, you may wish to set to `friendlier_id`.
+    #
     # * writer_settings: Settings to be passed to the Traject writer, by default a
     #   Traject::SolrJsonWriter. To maintain the default settings, best to merge
     #   your new ones into defaults.
@@ -118,6 +124,7 @@ module Kithe
       IndexableSettings.new(
         solr_url: "http://localhost:8983/solr/default",
         model_name_solr_field: "model_name_ssi",
+        solr_id_value_attribute: "id",
         writer_class_name: "Traject::SolrJsonWriter",
         writer_settings: {
           # as default we tell the solrjsonwriter to use no threads,

--- a/app/indexing/kithe/indexer.rb
+++ b/app/indexing/kithe/indexer.rb
@@ -21,6 +21,11 @@ module Kithe
   #   used, set `Kithe::Indexable.settings.model_name_solr_field=`)
   #
   # *  ID and model_name are set, so the AR object can be easily fetched later from Solr results.
+  #   * You can customize what Solr field the model_name is sent to with
+  #     `Kithe::Indexable.settings.model_name_solr_field=`, by default `model_name_ssi`, using
+  #     a blacklight dynamic field template `*_ssi`.
+  #   * You can customize what ActiveRecord model property is sent to Solr `id` field with
+  #     `Kithe::Indexable.settings.solr_id_value_attribute=`, by default the AR pk in model#id.
   #
   # Note that there are no built-in facilities for automatically sending every field of your model
   # to Solr, round-trippable or not. The expected usage pattern is sending to Solr only
@@ -43,8 +48,7 @@ module Kithe
     #
     # TODO We might not actually want to do these automatically, or allow it to be disabled?
     configure do
-      # hard-coded id -> id for now. id is a UUID. Can be made configurable?
-      to_field "id", obj_extract("id")
+      to_field "id", obj_extract(Kithe::Indexable.settings.solr_id_value_attribute)
       to_field Kithe::Indexable.settings.model_name_solr_field, obj_extract("class", "name")
     end
   end

--- a/spec/indexing/indexer_spec.rb
+++ b/spec/indexing/indexer_spec.rb
@@ -164,4 +164,20 @@ describe "Indexer end-to-end" do
       )
     end
   end
+
+  describe "custom model_name_solr_field" do
+    around do |example|
+      original = Kithe::Indexable.settings.model_name_solr_field
+      Kithe::Indexable.settings.model_name_solr_field = "my_model_name"
+      example.run
+      Kithe::Indexable.settings.model_name_solr_field = original
+    end
+
+    it "indexes specified attribute to id" do
+      result = indexer.map_record(work)
+      expect(result).to include(
+        "my_model_name" => ["TestWork"]
+      )
+    end
+  end
 end

--- a/spec/indexing/indexer_spec.rb
+++ b/spec/indexing/indexer_spec.rb
@@ -148,4 +148,20 @@ describe "Indexer end-to-end" do
       indexer.process_record(work)
     }.to raise_error(NameError)
   end
+
+  describe "custom solr_id_value_attribute" do
+    around do |example|
+      original = Kithe::Indexable.settings.solr_id_value_attribute
+      Kithe::Indexable.settings.solr_id_value_attribute = :friendlier_id
+      example.run
+      Kithe::Indexable.settings.solr_id_value_attribute = original
+    end
+
+    it "indexes specified attribute to id" do
+      result = indexer.map_record(work)
+      expect(result).to include(
+        "id" => [work.friendlier_id]
+      )
+    end
+  end
 end


### PR DESCRIPTION
..using Kithe::Indexable.settings.solr_id_value_attribute

Also added missing spec for model_name_solr_field setting