### PR TITLE
Move Kithe::Indexable.settings to Kithe.indexable_settings

### DIFF
--- a/app/indexing/kithe/indexable.rb
+++ b/app/indexing/kithe/indexable.rb
@@ -9,7 +9,7 @@ module Kithe
   # For a complete overview, see the [Guide Documentation](../../../guides/solr_indexing.md)
   #
   # The Solr instance to send updates to is global configuration:
-  #     Kithe::Indexable.settings.solr_url = "http://localhost:8983/solr/collection_name"
+  #     Kithe.indexable_settings.solr_url = "http://localhost:8983/solr/collection_name"
   #
   # To configure how a model is mapped to a Solr document, you create a `Kithe::Indexer` sub-class, which
   # can use our obj_extract method, as well as any other traject indexer code.
@@ -52,98 +52,6 @@ module Kithe
   module Indexable
     extend ActiveSupport::Concern
 
-    class IndexableSettings
-      attr_accessor :solr_url, :writer_class_name, :writer_settings,
-                    :model_name_solr_field, :solr_id_value_attribute, :disable_callbacks
-      def initialize(solr_url:, writer_class_name:, writer_settings:,
-                     model_name_solr_field:, solr_id_value_attribute:, disable_callbacks: false)
-        @solr_url = solr_url
-        @writer_class_name = writer_class_name
-        @writer_settings = writer_settings
-        @model_name_solr_field = model_name_solr_field
-        @solr_id_value_attribute = solr_id_value_attribute
-      end
-
-      # Use configured solr_url, and merge together with configured
-      # writer_settings
-      def writer_settings
-        if solr_url
-          { "solr.url" => solr_url }.merge(@writer_settings)
-        else
-          @writer_settings
-        end
-      end
-
-      # Turn writer_class_name into an actual Class object.
-      def writer_class
-        writer_class_name.constantize
-      end
-
-      # Instantiate a new writer based on `writer_class_name` and `writer_settings`
-      def writer_instance!(additional_settings = {})
-        writer_class.new(writer_settings.merge(additional_settings))
-      end
-    end
-
-    # Global Kithe::Indexable settings, actually a Kithe::Indexable::Settings
-    # object, but you will generally use it as a simple value object with getters
-    # and setters.
-    #
-    # * solr_url: Where to send to Solr when indexing, the base url
-    #
-    #     Kithe::Indexable.settings.solr_url = "http://localhost:8983/solr/collection_name"
-    #
-    # * model_name_solr_field: If you'd like a custom solr field to store model class name in.
-    #
-    #     Kithe::Indexable.settings.model_name_solr_field = "my_model_name_field"
-    #
-    # * solr_id_value_attribute: What attribute from your AR models to send to Solr
-    #   `id` uniqueKey field, default the AR `id` pk, you may wish to set to `friendlier_id`.
-    #
-    # * writer_settings: Settings to be passed to the Traject writer, by default a
-    #   Traject::SolrJsonWriter. To maintain the default settings, best to merge
-    #   your new ones into defaults.
-    #
-    #       Kithe::Indexable.settings.writer_settings.merge!(
-    #         # by default we send a softCommit on every update, maybe you
-    #         # want not to?
-    #         "solr_writer.solr_update_args" => {}
-    #         # extra long timeout?
-    #         "solr_writer.http_timeout" => 100
-    #       )
-    #
-    # * writer_class_name: By default Traject::SolrJsonWriter, but maybe
-    #   you want to set to some other Traject::Writer. The writer Kithe::Indexable
-    #   will send index add/remove requests to.
-    #
-    #       Kithe::Indexable.settings.writer_class_name = "Traject::SomeOtherWriter"
-    #
-    # * disable_callbacks: set to true to globally disable automatic after_commit
-    mattr_accessor :settings do
-      # set up default settings
-      IndexableSettings.new(
-        solr_url: "http://localhost:8983/solr/default",
-        model_name_solr_field: "model_name_ssi",
-        solr_id_value_attribute: "id",
-        writer_class_name: "Traject::SolrJsonWriter",
-        writer_settings: {
-          # as default we tell the solrjsonwriter to use no threads,
-          # no batching. softCommit on every update. Least surprising
-          # default configuration.
-          "solr_writer.thread_pool" => 0,
-          "solr_writer.batch_size" => 1,
-          "solr_writer.solr_update_args" => { softCommit: true },
-          "solr_writer.http_timeout" => 3,
-          "logger" => Rails.logger,
-
-          # MAYBE? no skippable exceptions please
-          # "solr_writer.skippable_exceptions" => []
-        },
-        disable_callbacks: false
-      )
-    end
-
-
     # Set some indexing parameters for the block yielded. For instance, to batch updates:
     #
     #     Kithe::Indexable.index_with(batching: true)
@@ -170,12 +78,12 @@ module Kithe
 
     # Are automatic after_commit callbacks currently enabled? Will check a number
     # of things to see, as we have a number of places these can be turned on/off.
-    # * Globally in `Kithe::Indexable.settings.disable_callback`
+    # * Globally in `Kithe.indexable_settings.disable_callback`
     # * On class or instance using class_attribute `kithe_indexable_auto_callbacks`
     # * If no kithe_indexable_mapper is configured on record, then no callbacks.
     # * Using thread-current settings usually set by .index_with
     def self.auto_callbacks?(model)
-      !Kithe::Indexable.settings.disable_callbacks &&
+      !Kithe.indexable_settings.disable_callbacks &&
         model.kithe_indexable_auto_callbacks &&
         model.kithe_indexable_mapper &&
         !ThreadSettings.current.disabled_callbacks?

--- a/app/indexing/kithe/indexable/record_index_updater.rb
+++ b/app/indexing/kithe/indexable/record_index_updater.rb
@@ -68,7 +68,7 @@ module Kithe
       # Could be an explicit writer passed into #initialize, or a current thread-settings
       # writer, or a new writer created from global settings.
       def writer
-        @writer ||= ThreadSettings.current.writer  || Kithe::Indexable.settings.writer_instance!
+        @writer ||= ThreadSettings.current.writer  || Kithe.indexable_settings.writer_instance!
       end
 
       # Is this record supposed to be represented in the solr index?

--- a/app/indexing/kithe/indexable/thread_settings.rb
+++ b/app/indexing/kithe/indexable/thread_settings.rb
@@ -81,7 +81,7 @@ module Kithe
         @writer ||= begin
           if @batching
             @local_writer = true
-            Kithe::Indexable.settings.writer_instance!("solr_writer.batch_size" => 100)
+            Kithe.indexable_settings.writer_instance!("solr_writer.batch_size" => 100)
           end
         end
       end

--- a/app/indexing/kithe/indexer.rb
+++ b/app/indexing/kithe/indexer.rb
@@ -18,14 +18,14 @@ module Kithe
   # * A Kithe::Indexer will automatically index the source record #id to Solr object
   #   #id, and the source record class name to Solr field `model_name_ssi`. (That uses
   #   Blacklight conventions for dynamic field names, if you'd like to change the field name
-  #   used, set `Kithe::Indexable.settings.model_name_solr_field=`)
+  #   used, set `Kithe.indexable_settings.model_name_solr_field=`)
   #
   # *  ID and model_name are set, so the AR object can be easily fetched later from Solr results.
   #   * You can customize what Solr field the model_name is sent to with
-  #     `Kithe::Indexable.settings.model_name_solr_field=`, by default `model_name_ssi`, using
+  #     `Kithe.indexable_settings.model_name_solr_field=`, by default `model_name_ssi`, using
   #     a blacklight dynamic field template `*_ssi`.
   #   * You can customize what ActiveRecord model property is sent to Solr `id` field with
-  #     `Kithe::Indexable.settings.solr_id_value_attribute=`, by default the AR pk in model#id.
+  #     `Kithe.indexable_settings.solr_id_value_attribute=`, by default the AR pk in model#id.
   #
   # Note that there are no built-in facilities for automatically sending every field of your model
   # to Solr, round-trippable or not. The expected usage pattern is sending to Solr only
@@ -48,8 +48,8 @@ module Kithe
     #
     # TODO We might not actually want to do these automatically, or allow it to be disabled?
     configure do
-      to_field "id", obj_extract(Kithe::Indexable.settings.solr_id_value_attribute)
-      to_field Kithe::Indexable.settings.model_name_solr_field, obj_extract("class", "name")
+      to_field "id", obj_extract(Kithe.indexable_settings.solr_id_value_attribute)
+      to_field Kithe.indexable_settings.model_name_solr_field, obj_extract("class", "name")
     end
   end
 end

--- a/app/indexing/kithe/solr_util.rb
+++ b/app/indexing/kithe/solr_util.rb
@@ -16,7 +16,7 @@ module Kithe
     #        delete(id)
     #     end
     #
-    # It is searching for any Solr object with a `Kithe::Indexable.settings.model_name_solr_field`
+    # It is searching for any Solr object with a `Kithe.indexable_settings.model_name_solr_field`
     # field (default `model_name_ssi`). Then, it takes the ID and makes sure it exists in
     # the database using Kithe::Model. At the moment we are assuming everything is in Kithe::Model,
     # rather than trying to use the `model_name_ssi` to fetch from different tables. Could
@@ -26,10 +26,10 @@ module Kithe
     #
     # A bit hacky implementation, it might be nice to support a progress bar, we
     # don't now.
-    def self.solr_orphan_ids(batch_size: 100, solr_url: Kithe::Indexable.settings.solr_url)
+    def self.solr_orphan_ids(batch_size: 100, solr_url: Kithe.indexable_settings.solr_url)
       return enum_for(:solr_index_orphan_ids) unless block_given?
 
-      model_name_solr_field = Kithe::Indexable.settings.model_name_solr_field
+      model_name_solr_field = Kithe.indexable_settings.model_name_solr_field
       solr_page = -1
 
       rsolr = RSolr.connect :url => solr_url
@@ -53,7 +53,7 @@ module Kithe
     end
 
     # Finds any Solr objects that have a `model_name_ssi` field
-    # (or `Kithe::Indexable.settings.model_name_solr_field` if non-default), but don't
+    # (or `Kithe.indexable_settings.model_name_solr_field` if non-default), but don't
     # exist in the rdbms, and deletes them from Solr, then issues a commit.
     #
     # Under normal use, you shouldn't have to do this, but can if your Solr index
@@ -65,7 +65,7 @@ module Kithe
     # A bit hacky implementation, it might be nice to have a progress bar, we don't now.
     #
     # Does return an array of any IDs deleted.
-    def self.delete_solr_orphans(batch_size: 100, solr_url: Kithe::Indexable.settings.solr_url)
+    def self.delete_solr_orphans(batch_size: 100, solr_url: Kithe.indexable_settings.solr_url)
       rsolr = RSolr.connect :url => solr_url
       deleted_ids = []
 
@@ -84,7 +84,7 @@ module Kithe
     #
     # Intended for dev/test instances, not really production.
     # @param commit :soft, :hard, or false. Default :hard
-    def self.delete_all(solr_url: Kithe::Indexable.settings.solr_url, commit: :hard)
+    def self.delete_all(solr_url: Kithe.indexable_settings.solr_url, commit: :hard)
       rsolr = RSolr.connect :url => solr_url
 
       # RSolr is a bit under-doc'd, but this SEEMS to work to send a commit

--- a/guides/solr_indexing.md
+++ b/guides/solr_indexing.md
@@ -12,7 +12,7 @@ The kithe indexing code does not assume you are using Blacklight, although you c
 
 ```ruby
 # perhaps in config/initializers/kithe_indexable.rb
-Kithe::Indexable.settings.solr_url = ENV['SOLR_URL']
+Kithe.indexable_settings.solr_url = ENV['SOLR_URL']
 
 # or wherever else you'd like to get it from, use your own conditional logic
 # for different url depending on Rails.env, etc.
@@ -62,7 +62,7 @@ You will generally need the pk and class name of the object in the Solr index so
 
 The object primary key in `id`, which for Kithe::Models is a UUIDv4, will be sent to Solr field `id`. (Not currently customizable or disable-able)
 
-The object class name will by default be sent to Solr field `model_name_ssi`. You can change this field with `Kithe::Indexable.settings.model_name_solr_field=`, or set it to false to disable.
+The object class name will by default be sent to Solr field `model_name_ssi`. You can change this field with `Kithe.indexable_settings.model_name_solr_field=`, or set it to false to disable.
 
 ### Set the indexer on your work class, enabling automatic callback-based indexing
 
@@ -120,7 +120,7 @@ As `index_with(batching: true)` only creates a Traject::Writer lazily on demand,
 
 Perhaps you have indexing set up, by setting a `kithe_indexable_mapper` in your model class, but you want to disable the automatic callbacks, either temporarily or permanently. There are a variety you can do that.
 
-* Disable globally and universally:  `Kithe::Indexable.settings.disable_callbacks = true`
+* Disable globally and universally:  `Kithe.indexable_settings.disable_callbacks = true`
 * Disable globally for a particular class, using a Rails class_attribute:
   `SomeClass.kithe_indexable_auto_callbacks = false`
 * Disable for a particular instance, using that same class_attribute:
@@ -171,14 +171,14 @@ For RSpec, add to your `spec_helper.rb` or `rails_helper.rb`:
 ```ruby
 RSpec.configure do |config|
   config.before(:suite) do
-    Kithe::Indexable.settings.disable_callbacks = true
+    Kithe.indexable_settings.disable_callbacks = true
   end
 
   config.around(:each, :indexable_callbacks) do |example|
-    original = Kithe::Indexable.settings.disable_callbacks
-    Kithe::Indexable.settings.disable_callbacks = !example.metadata[:indexable_callbacks]
+    original = Kithe.indexable_settings.disable_callbacks
+    Kithe.indexable_settings.disable_callbacks = !example.metadata[:indexable_callbacks]
     example.run
-    Kithe::Indexable.settings.disable_callbacks = original
+    Kithe.indexable_settings.disable_callbacks = original
   end
 end
 ```
@@ -216,7 +216,7 @@ and every time it sends an update to Solr, it does it with a softCommit.
 
 You can customize the Trjaect::Writer class used globally:
 
-    Kithe::Indexable.settings.writer_class_name = "Whatever::CompatibleTrajectWriter"
+    Kithe.indexable_settings.writer_class_name = "Whatever::CompatibleTrajectWriter"
 
 This would also be a way to get indexing to go to something other than Solr, if an appropriate `Traject::Writer` were written.
 

--- a/lib/kithe.rb
+++ b/lib/kithe.rb
@@ -1,4 +1,5 @@
 require "kithe/engine"
+require 'kithe/indexable_settings'
 
 module Kithe
   # for ruby-progressbar
@@ -15,4 +16,67 @@ module Kithe
   def self.railtie_namespace
     Kithe::Engine
   end
+
+  # Global Kithe::Indexable settings, actually a Kithe::IndexableSettings
+  # object, but you will generally use it as a simple value object with getters
+  # and setters.
+  #
+  # * solr_url: Where to send to Solr when indexing, the base url
+  #
+  #     Kithe.indexable_settings.solr_url = "http://localhost:8983/solr/collection_name"
+  #
+  # * model_name_solr_field: If you'd like a custom solr field to store model class name in.
+  #
+  #     Kithe.indexable_settings.model_name_solr_field = "my_model_name_field"
+  #
+  # * solr_id_value_attribute: What attribute from your AR models to send to Solr
+  #   `id` uniqueKey field, default the AR `id` pk, you may wish to set to `friendlier_id`.
+  #
+  # * writer_settings: Settings to be passed to the Traject writer, by default a
+  #   Traject::SolrJsonWriter. To maintain the default settings, best to merge
+  #   your new ones into defaults.
+  #
+  #       Kithe.indexable_settings.writer_settings.merge!(
+  #         # by default we send a softCommit on every update, maybe you
+  #         # want not to?
+  #         "solr_writer.solr_update_args" => {}
+  #         # extra long timeout?
+  #         "solr_writer.http_timeout" => 100
+  #       )
+  #
+  # * writer_class_name: By default Traject::SolrJsonWriter, but maybe
+  #   you want to set to some other Traject::Writer. The writer Kithe::Indexable
+  #   will send index add/remove requests to.
+  #
+  #       Kithe.indexable_settings.writer_class_name = "Traject::SomeOtherWriter"
+  #
+  # * disable_callbacks: set to true to globally disable automatic after_commit
+  #
+  #
+  # The settings need to live here not in Kithe::Indexable, to avoid terrible
+  # Rails dev-mode class-reloading weirdnesses. This module is not reloaded.
+  mattr_accessor :indexable_settings do
+  # set up default settings
+  IndexableSettings.new(
+    solr_url: "http://localhost:8983/solr/default",
+    model_name_solr_field: "model_name_ssi",
+    solr_id_value_attribute: "id",
+    writer_class_name: "Traject::SolrJsonWriter",
+    writer_settings: {
+      # as default we tell the solrjsonwriter to use no threads,
+      # no batching. softCommit on every update. Least surprising
+      # default configuration.
+      "solr_writer.thread_pool" => 0,
+      "solr_writer.batch_size" => 1,
+      "solr_writer.solr_update_args" => { softCommit: true },
+      "solr_writer.http_timeout" => 3,
+      "logger" => Rails.logger,
+
+      # MAYBE? no skippable exceptions please
+      # "solr_writer.skippable_exceptions" => []
+    },
+    disable_callbacks: false
+  )
+end
+
 end

--- a/lib/kithe/blacklight_tools/search_service_bulk_load.rb
+++ b/lib/kithe/blacklight_tools/search_service_bulk_load.rb
@@ -8,7 +8,7 @@ module Kithe
     #
     # * Assumes all documents that come back in the Solr results was indexed Kithe::Model, and
     #   their Solr ID's are the Kithe::Model `id` pk, or from the AR model attribute name
-    #   set in `Kithe::Indexable.settings.solr_id_value_attribute`
+    #   set in `Kithe.indexable_settings.solr_id_value_attribute`
     #
     # * Requires your SolrDocument class to have a `model` attribute, you can just add
     #   `attr_accessor :model` to your local SolrDocument class BL generated in
@@ -34,11 +34,11 @@ module Kithe
         if bulk_load_records
           id_hash = response.documents.collect {|r| [r.id, r] }.to_h
 
-          scope = Kithe::Model.where(Kithe::Indexable.settings.solr_id_value_attribute => id_hash.keys)
+          scope = Kithe::Model.where(Kithe.indexable_settings.solr_id_value_attribute => id_hash.keys)
           scope = scope.instance_exec(&bulk_load_scope) if bulk_load_scope
 
           scope.find_each do |model|
-            id_hash[model.send(Kithe::Indexable.settings.solr_id_value_attribute)].model = model
+            id_hash[model.send(Kithe.indexable_settings.solr_id_value_attribute)].model = model
           end
 
           orphaned_solr_docs = id_hash.values.select { |doc| doc.model.nil? }

--- a/lib/kithe/indexable_settings.rb
+++ b/lib/kithe/indexable_settings.rb
@@ -1,0 +1,34 @@
+module Kithe
+  class IndexableSettings
+    attr_accessor :solr_url, :writer_class_name, :writer_settings,
+                  :model_name_solr_field, :solr_id_value_attribute, :disable_callbacks
+    def initialize(solr_url:, writer_class_name:, writer_settings:,
+                   model_name_solr_field:, solr_id_value_attribute:, disable_callbacks: false)
+      @solr_url = solr_url
+      @writer_class_name = writer_class_name
+      @writer_settings = writer_settings
+      @model_name_solr_field = model_name_solr_field
+      @solr_id_value_attribute = solr_id_value_attribute
+    end
+
+    # Use configured solr_url, and merge together with configured
+    # writer_settings
+    def writer_settings
+      if solr_url
+        { "solr.url" => solr_url }.merge(@writer_settings)
+      else
+        @writer_settings
+      end
+    end
+
+    # Turn writer_class_name into an actual Class object.
+    def writer_class
+      writer_class_name.constantize
+    end
+
+    # Instantiate a new writer based on `writer_class_name` and `writer_settings`
+    def writer_instance!(additional_settings = {})
+      writer_class.new(writer_settings.merge(additional_settings))
+    end
+  end
+end

--- a/spec/indexing/indexable_spec.rb
+++ b/spec/indexing/indexable_spec.rb
@@ -5,12 +5,12 @@ describe Kithe::Indexable, type: :model do
     @solr_url = "http://localhost:8983/solr/collection1"
     @solr_update_url = "#{@solr_url}/update/json?softCommit=true"
 
-    @original_solr_url = Kithe::Indexable.settings.solr_url
-    Kithe::Indexable.settings.solr_url =@solr_url
+    @original_solr_url = Kithe.indexable_settings.solr_url
+    Kithe.indexable_settings.solr_url =@solr_url
   end
 
   after do
-    Kithe::Indexable.settings.solr_url = @original_solr_url
+    Kithe.indexable_settings.solr_url = @original_solr_url
   end
 
   temporary_class("TestWork") do
@@ -101,10 +101,10 @@ describe Kithe::Indexable, type: :model do
 
     describe "with global disable_callbacks" do
       around do |example|
-        original = Kithe::Indexable.settings.disable_callbacks
-        Kithe::Indexable.settings.disable_callbacks = true
+        original = Kithe.indexable_settings.disable_callbacks
+        Kithe.indexable_settings.disable_callbacks = true
         example.run
-        Kithe::Indexable.settings.disable_callbacks = original
+        Kithe.indexable_settings.disable_callbacks = original
       end
 
       it "does not index" do
@@ -125,7 +125,7 @@ describe Kithe::Indexable, type: :model do
         thread_settings = nil
         it "batches solr updates" do
           stub_request(:post, @solr_update_url)
-          expect(Kithe::Indexable.settings.writer_class_name.constantize).to receive(:new).and_call_original
+          expect(Kithe.indexable_settings.writer_class_name.constantize).to receive(:new).and_call_original
 
           Kithe::Indexable.index_with(batching: true) do
             TestWork.create!(title: "test1")
@@ -142,7 +142,7 @@ describe Kithe::Indexable, type: :model do
         end
 
         it "creates no writer if no updates happen" do
-          expect(Kithe::Indexable.settings.writer_class_name.constantize).not_to receive(:new)
+          expect(Kithe.indexable_settings.writer_class_name.constantize).not_to receive(:new)
           Kithe::Indexable.index_with(batching: true) do
           end
         end
@@ -150,7 +150,7 @@ describe Kithe::Indexable, type: :model do
         it "respects non-default on_finish" do
           stub_request(:post, @solr_update_url)
           stub_request(:get, "#{@solr_url}/update/json?commit=true")
-          expect(Kithe::Indexable.settings.writer_class_name.constantize).to receive(:new).and_call_original
+          expect(Kithe.indexable_settings.writer_class_name.constantize).to receive(:new).and_call_original
 
           Kithe::Indexable.index_with(batching: true, on_finish: ->(w){ w.flush; w.commit(commit: true) }) do
             TestWork.create!(title: "test1")

--- a/spec/indexing/indexer_spec.rb
+++ b/spec/indexing/indexer_spec.rb
@@ -151,10 +151,10 @@ describe "Indexer end-to-end" do
 
   describe "custom solr_id_value_attribute" do
     around do |example|
-      original = Kithe::Indexable.settings.solr_id_value_attribute
-      Kithe::Indexable.settings.solr_id_value_attribute = :friendlier_id
+      original = Kithe.indexable_settings.solr_id_value_attribute
+      Kithe.indexable_settings.solr_id_value_attribute = :friendlier_id
       example.run
-      Kithe::Indexable.settings.solr_id_value_attribute = original
+      Kithe.indexable_settings.solr_id_value_attribute = original
     end
 
     it "indexes specified attribute to id" do
@@ -167,10 +167,10 @@ describe "Indexer end-to-end" do
 
   describe "custom model_name_solr_field" do
     around do |example|
-      original = Kithe::Indexable.settings.model_name_solr_field
-      Kithe::Indexable.settings.model_name_solr_field = "my_model_name"
+      original = Kithe.indexable_settings.model_name_solr_field
+      Kithe.indexable_settings.model_name_solr_field = "my_model_name"
       example.run
-      Kithe::Indexable.settings.model_name_solr_field = original
+      Kithe.indexable_settings.model_name_solr_field = original
     end
 
     it "indexes specified attribute to id" do


### PR DESCRIPTION
Necessary to play well with Rails dev-mode class reloading. Since the Kithe::Indexable class gets reloaded by Rails sometimes, when it does settings set on Kithe::Indexable.settings in an initializer were lost.

We should keep all settings in the 'Kithe' module, which does not get reloaded. This is actually what Rails guide recommends, although it doesn't explain why.
https://guides.rubyonrails.org/engines.html#configuring-an-engine