### PR TITLE
Build with_representative_derivatives scope into Kithe::Model

### DIFF
--- a/app/models/kithe/model.rb
+++ b/app/models/kithe/model.rb
@@ -6,6 +6,14 @@ class Kithe::Model < ActiveRecord::Base
   include AttrJson::Record::Dirty
   include Kithe::Indexable
 
+  # A handy scope for eager-loading all representatives and all of their derivatives.
+  #
+  # Works on hetereogenous collections of Works and Assets -- the Assets need
+  # :derivatives directly referenced (since they don't really have a leaf_representative assoc),
+  # the works need :leaf_representative => :derivatives.
+  #
+  # Loading all three of these on result sets of hundreds of values is still relatively quick.
+  scope :with_representative_derivatives, -> { includes(:derivatives, leaf_representative: :derivatives) }
 
   # While Rails STI means the actual specific class is in `type`, sometimes
   # it can be convenient to fetch on a top category of Kithe::Model without using

--- a/guides/work_representative.md
+++ b/guides/work_representative.md
@@ -63,3 +63,11 @@ results = Kithe::Model.all.includes(:derivatives, leaf_representative: :derivati
 All "leaf" representatives and derivatives will be eager-loaded by ActiveRecord, and for anything in your results list you can ask for `thing.representative` or `thing.representative.derivatives` without triggering additional db fetches (you are avoiding the "n+1 problem").
 
 So you might then get the actual "derivative" object to display for any hit, with eg `some_model.leaf_representative.derivative_for(:thumbnail)`, without accidentally triggering n+1 queries.
+
+Because this particular `includes` is a _bit_ tricky and so commonly needed, it's built into kithe.
+Use `with_representative_derivatives` wherever you can use a Rails scope to pre-load all leaf_representatives and all their derivatives.
+
+```ruby
+  some_work.members.with_representative_derivatives
+  Kithe::Work.with_representative_derivatives.where(something: something)
+```

--- a/spec/factories/kithe_assets.rb
+++ b/spec/factories/kithe_assets.rb
@@ -22,5 +22,13 @@ FactoryBot.define do
         end
       end
     end
+
+    # No bytestreams, but a derivative
+    trait :faked_derivatives do
+      derivatives {[
+        Kithe::Derivative.new(key: "one"),
+        Kithe::Derivative.new(key: "two")
+      ]}
+    end
   end
 end

--- a/spec/models/kithe/model_spec.rb
+++ b/spec/models/kithe/model_spec.rb
@@ -73,5 +73,24 @@ module Kithe
       end
     end
 
+    describe "with_representative_derivatives scope" do
+      let(:work) {
+        FactoryBot.create(:kithe_work, title: "test for preload",
+          members: [
+            FactoryBot.create(:kithe_work, representative: FactoryBot.create(:kithe_asset, :faked_derivatives)),
+            FactoryBot.create(:kithe_asset, :faked_derivatives),
+            FactoryBot.create(:kithe_asset, :faked_derivatives)
+          ])
+      }
+      it "pre-loads all representatives and derivatives" do
+        members = work.members.with_representative_derivatives.to_a
+
+        members.each do |member|
+          expect(member.association(:leaf_representative)).to be_loaded
+          expect(member.leaf_representative.association(:derivatives)).to be_loaded
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
For pre-loading all leaf_representatives and all of their derivatives, in any possibly heteregenous list of any
Kithe::Models.

This is a BIT confusing and a commonly needed thing to do, so we should build in a scope for it.