### PR TITLE
Fix VipsCliImageToJpeg to preserve original dimensions if no max_width is given

### DIFF
--- a/app/derivative_transformers/kithe/vips_cli_image_to_jpeg.rb
+++ b/app/derivative_transformers/kithe/vips_cli_image_to_jpeg.rb
@@ -64,9 +64,12 @@ module Kithe
         vips_args.concat ["--size", "#{max_width}x65500"]
         vips_args.concat ["-o", "#{tempfile.path}#{vips_jpg_params}"]
       else
-        vips_args.concat [vips_thumbnail_command, original_file.path]
-        vips_args.concat maybe_profile_normalization_args
-        vips_args.concat ["-o", "#{tempfile.path}#{vips_jpg_params}"]
+        # If we arne't making a thumbnail, we need to use `vips copy` instead of `vipsthumbnail`,
+        # to avoid it changing height/width on us. There might be another way.
+        #
+        # Yes, this means we can't do thumbnail-mode normalizations.
+        vips_args.concat [vips_command, "copy", original_file.path]
+        vips_args.concat ["#{tempfile.path}#{vips_jpg_params}"]
       end
 
       TTY::Command.new(printer: :null).run(*vips_args)

--- a/kithe.gemspec
+++ b/kithe.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rsolr", "~> 2.2" # for some low-level solr stuff
 
   s.add_development_dependency "appraisal" # CI testing under multiple rails versions
+  s.add_development_dependency "dimensions" # checking image width of transformers in tests
 
 
   s.add_development_dependency "pg"

--- a/spec/derivative_transformers/vips_cli_image_to_jpeg_spec.rb
+++ b/spec/derivative_transformers/vips_cli_image_to_jpeg_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'dimensions'
 
 # mostly smoke tests, we don't verify much about the output images at present
 describe Kithe::VipsCliImageToJpeg do
@@ -21,16 +22,21 @@ describe Kithe::VipsCliImageToJpeg do
         expect(output).to be_kind_of(Tempfile)
         expect(Marcel::MimeType.for(output)).to eq("image/jpeg")
 
+        expect(Dimensions.width(output.path)).to eq(width)
+
         output.close!
       end
     end
   end
 
   describe "not thumbnail mode" do
+    let(:original_width) { Dimensions.width(input_file.path) }
     it "converts" do
       output = Kithe::VipsCliImageToJpeg.new(thumbnail_mode: false).call(input_file)
       expect(output).to be_kind_of(Tempfile)
       expect(Marcel::MimeType.for(output)).to eq("image/jpeg")
+
+      expect(Dimensions.width(output)).to eq(original_width)
 
       output.close!
     end
@@ -42,6 +48,8 @@ describe Kithe::VipsCliImageToJpeg do
         output = Kithe::VipsCliImageToJpeg.new(thumbnail_mode: false, max_width: width).call(input_file)
         expect(output).to be_kind_of(Tempfile)
         expect(Marcel::MimeType.for(output)).to eq("image/jpeg")
+
+        expect(Dimensions.width(output.path)).to eq(width)
 
         output.close!
       end


### PR DESCRIPTION
With specs on size of output file, using pure-ruby "dimensions" gem to easily check dimensions of output files.