### PR TITLE
avoid symbols in promotion diretives that can't be serialized by ActiveJob

### DIFF
--- a/app/models/kithe/timing_promotion_directive.rb
+++ b/app/models/kithe/timing_promotion_directive.rb
@@ -21,7 +21,7 @@ module Kithe
     attr_reader :directive_key, :directives
 
     def initialize(key:, directives: )
-      @directive_key = key.to_sym
+      @directive_key = key.to_s
       @directives = directives
 
       unless ALLOWED_VALUES.include?(directive_value)

--- a/spec/models/kithe/asset/asset_promotion_hooks_spec.rb
+++ b/spec/models/kithe/asset/asset_promotion_hooks_spec.rb
@@ -216,13 +216,13 @@ describe "Kithe::Asset promotion hooks", queue_adapter: :inline do
     it "can set from class attribute" do
       Kithe::Asset.promotion_directives = { promote: :inline }
       asset = Kithe::Asset.new
-      expect(asset.file_attacher.promotion_directives).to eq(promote: :inline)
+      expect(asset.file_attacher.promotion_directives).to eq("promote" => "inline")
     end
 
     it "can set from instance writer" do
       asset = Kithe::Asset.new
       asset.set_promotion_directives(promote: :inline)
-      expect(asset.file_attacher.promotion_directives).to eq(promote: :inline)
+      expect(asset.file_attacher.promotion_directives).to eq("promote" => "inline")
     end
   end
 end


### PR DESCRIPTION
Not sure why this doesn't never work, but it was causing problems in my app -- only in one rare odd case,
not generally. Sorry, don't have a test for bug. But let's just switch em to all strings.