### PR TITLE
Silence errors from store_dimensions

### DIFF
--- a/app/uploaders/kithe/asset_uploader.rb
+++ b/app/uploaders/kithe/asset_uploader.rb
@@ -33,7 +33,10 @@ module Kithe
     plugin :determine_mime_type, analyzer: :marcel
 
     # Will save height and width to metadata for image types. (Won't for non-image types)
-    plugin :store_dimensions
+    # on_error: :ignore is consistent with behavior < 2.19.0 shrine. We don't want
+    # to log on errors of unrecognized file type for extracting height/width, that's
+    # fine.
+    plugin :store_dimensions, on_error: :ignore
 
     # promotion and deletion will be in background.
     plugin :backgrounding

--- a/app/uploaders/kithe/derivative_uploader.rb
+++ b/app/uploaders/kithe/derivative_uploader.rb
@@ -9,7 +9,11 @@ module Kithe
     plugin :activerecord
 
     plugin :determine_mime_type, analyzer: :marcel
-    plugin :store_dimensions
+    # Will save height and width to metadata for image types. (Won't for non-image types)
+    # on_error: :ignore is consistent with behavior < 2.19.0 shrine. We don't want
+    # to log on errors of unrecognized file type for extracting height/width, that's
+    # fine.
+    plugin :store_dimensions, on_error: :ignore
 
     # Useful in case consumers want it, and doesn't harm anything to be available.
     # https://github.com/shrinerb/shrine/blob/master/doc/plugins/rack_response.md

--- a/kithe.gemspec
+++ b/kithe.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "attr_json", "< 2.0.0"
 
   s.add_dependency "simple_form", "~> 4.0"
-  s.add_dependency "shrine", "~> 2.14" # file attachment handling
+  s.add_dependency "shrine", "~> 2.19" # file attachment handling
   s.add_dependency "shrine-url", "~> 2.0"
   s.add_dependency "fastimage", "~> 2.0.0" # use by default for image dimensions
   s.add_dependency "marcel" # use by default for content-type detection


### PR DESCRIPTION
This is consistent with shrine behavior < 2.19.0 shrine.

We don't want errors printed to console/log for unrecognized type for extracting dimensions. As they weren't before. Maybe we ideally want other errors, but rather than spend time on it now, we'll just restore 2.18.0 behavior.

Requires us saying we need shrine at least 2.19.0 so we have the on_error option.