### PR TITLE
repeatable_attr_input can take html_attributes in case of generated simple html input

### DIFF
--- a/app/simple_form_enhancements/kithe/form_builder.rb
+++ b/app/simple_form_enhancements/kithe/form_builder.rb
@@ -24,13 +24,18 @@ class Kithe::FormBuilder < SimpleForm::FormBuilder
   #   you'd pass to a form builder.
   # @param build [Boolean] nil default, or set to :at_least_one to have an empty input
   #   generated even if the model includes no elements.
+  # @param html_attributes [Hash] hash of additional attributes to add to a generated simple
+  #   primitive <input> tag. Useful for data- attributes for custom JS behavior. Only valid
+  #   if the generator will be generating a simple primtiive input for you, otherwise will
+  #   raise ArgumentError if you try.
   # @yield [builder] For model-type attributes (not primitives), yields a sub-builder similar to `fields_for`.
+  # @yiieldparam [SimpleForm::FormBuilder] builder
   # @yield [input_name, value] For primitive-type attributes, different yield.
-  # @yieldparam [String] that should be used as HTML "name" attribute on input
-  # @yieldparam value that should be used as existing value when generating input for
+  # @yieldparam [String] input_name  that should be used as HTML "name" attribute on input
+  # @yieldparam [String] value that should be used as existing value when generating input for
   #   primitive, usually by passing to `value` attribute in some input builder.
-  def repeatable_attr_input(attr_name, build: nil, &block)
+  def repeatable_attr_input(attr_name, html_attributes: nil, build: nil, &block)
     #repeatable_main_content(attr_name, &block)
-    Kithe::RepeatableInputGenerator.new(self, attr_name, block, build: build).render
+    Kithe::RepeatableInputGenerator.new(self, attr_name, block, html_attributes: html_attributes, build: build).render
   end
 end

--- a/guides/forms.md
+++ b/guides/forms.md
@@ -81,6 +81,14 @@ If you only want a repeatable text box, you can simply not use a block argument:
 <% end %>
 ```
 
+You can also specify additional HTML attributes for the input tag, in standard Rails style, say if you need a data tag to trigger some JS functionality:
+
+```
+<%= kithe_form_for(@work) do |form| %>
+   <%= form.repeatable_attr_input(:array_of_strings, html_attributes: { "data-something" => "value" }) %>
+<% end %>
+```
+
 If you do need to customize the repeatable HTML unit -- say you need it to be a select menu instead of a text entry -- you can provide a block. The yielded block arguments are different: There's no sub-form-builder involved. Instead, yielded are a string input name you should use in whatever input you build, and the value to build the current unit with.
 
 ```ruby

--- a/spec/simple_form_enhancements/repeatable_input_generator_spec.rb
+++ b/spec/simple_form_enhancements/repeatable_input_generator_spec.rb
@@ -216,6 +216,24 @@ describe Kithe::RepeatableInputGenerator, type: :helper do
       expect(id_values.count).to eq(id_values.uniq.count)
     end
 
+    describe(:with_html_attributes) do
+      let(:generator) do
+        generator = nil
+        helper.simple_form_for(instance, url: "http://example/target") do |form|
+          generator = Kithe::RepeatableInputGenerator.new(form,
+            :string_array, nil,
+            html_attributes: { data: { foo: "bar" } } )
+        end
+        generator
+      end
+
+      it "has attributes on input" do
+        links = assert_select('input[name="test_work[string_array_attributes][]"]:not([type=hidden])')
+        expect(links.all? {|el| el['data-foo'] == "bar"}).to be(true)
+      end
+
+    end
+
     describe "build: :at_least_one" do
       let(:generator) do
         generator = nil


### PR DESCRIPTION
Meant for adding data- attributes to trigger custom local JS. Needed/useful in scihist app.