### PR TITLE
Allow a derivative to be manually set on a non-stored file, and not be deleted

### DIFF
--- a/app/models/kithe/asset.rb
+++ b/app/models/kithe/asset.rb
@@ -226,8 +226,12 @@ class Kithe::Asset < Kithe::Model
     Kithe::Asset.where(id: self.id).where("file_data -> 'metadata' ->> 'sha512' = ?", self.sha512).lock.first
   end
 
+  # Intentionally only true if there WAS a sha512 before AND it's changed.
+  # Allowing false on nil previous sha512 allows certain conditions, mostly only
+  # in testing, where you want to assign a derivative to not-yet-promoted file.
   def saved_change_to_file_sha?
     saved_change_to_file_data? &&
+      saved_change_to_file_data.first.try(:dig, "metadata", "sha512") != nil &&
       saved_change_to_file_data.first.try(:dig, "metadata", "sha512") !=
         saved_change_to_file_data.second.try(:dig, "metadata", "sha512")
   end

--- a/spec/models/kithe/asset_spec.rb
+++ b/spec/models/kithe/asset_spec.rb
@@ -192,5 +192,17 @@ RSpec.describe Kithe::Asset, type: :model do
       expect{ existing_derivative.reload }.to raise_error(ActiveRecord::RecordNotFound)
       expect(existing_stored_file.exists?).to be(false)
     end
+
+    it "allows derivative to be set on un-promoted file though" do
+      # mostly needed for testing scenarios, not otherwise expected.
+      filepath = Kithe::Engine.root.join("spec/test_support/images/1x1_pixel.jpg")
+      asset = Kithe::Asset.new(file: File.open(filepath), title: "test").tap do |a|
+        a.file_attacher.set_promotion_directives(skip_callbacks: true)
+      end
+      asset.derivatives << Kithe::Derivative.new(file: File.open(filepath), key: "test")
+      asset.save!
+      asset.reload
+      expect(asset.derivatives.count).to eq 1
+    end
   end
 end


### PR DESCRIPTION
Our callback logic tries to ensure that "stale" derivatives aren't around, by deleting derivatives if the SHA256 changes.

This meant if you set a derivative on a file before a SHA was calculated, it would be deleted once the asset was promoted and had a SHA assigned.

This was getting in the way of some test scenarios -- it's hard to figure out how to set up tests efficiently for this stuff. So for now, we will allow a derivative set when there is NO sha to persist once a sha is set. The higher level APIs may still raise if you try to create derivatives on a non-promoted file without a digest. That's fine. This change is mainly being done for testing/manual/hacky scenarios.