### PR TITLE
Allow simple_form 5.x

### DIFF
--- a/kithe.gemspec
+++ b/kithe.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", ">= 5.2.1", "< 6.1"
   s.add_dependency "attr_json", "< 2.0.0"
 
-  s.add_dependency "simple_form", "~> 4.0"
+  s.add_dependency "simple_form", ">= 4.0", "< 6.0"
   s.add_dependency "shrine", "~> 2.14" # file attachment handling
   s.add_dependency "shrine-url", "~> 2.0"
   s.add_dependency "fastimage", "~> 2.0.0" # use by default for image dimensions


### PR DESCRIPTION
We still allow simple_form 4.x too, cause why not. 4.x and 5.0 actually barely differ, 5.0 has a security fix, which necessitatted a small backwards breaking change in a rarely used feature (that kithe does not use).

http://blog.plataformatec.com.br/2019/09/incorrect-access-control-in-simple-form-cve-2019-16676/

No future backwards-breaking changes would be allowed in future simple_form 5.x releases if semver is being respected. So see no need not to allow both 4.x and 5.x, kithe should be compatible with both. Individual apps can specify 5.x only if they want to ensure security fix, kithe's responsibility is to allow that, not to enforce it.