### PR TITLE
obj_extract ignores empty string values from output

### DIFF
--- a/spec/indexing/obj_extract_spec.rb
+++ b/spec/indexing/obj_extract_spec.rb
@@ -22,6 +22,12 @@ describe "ObjExtract traject macro" do
       result = indexer.map_record(OpenStruct.new(title: "title value"))
       expect(result["result"]).to eq(["title value"])
     end
+
+    it "ignores empty string" do
+      result = indexer.map_record(OpenStruct.new(title: ""))
+      expect(result["result"]).to be_nil
+      expect(result.keys).not_to include("result")
+    end
   end
 
   describe "primitive array attribute" do
@@ -45,6 +51,17 @@ describe "ObjExtract traject macro" do
       result = indexer.map_record(OpenStruct.new(title: ["title value1", "title value2"]))
       expect(result["result"]).to eq(["title value1", "title value2"])
     end
+
+    it "filters out empty strings" do
+      result = indexer.map_record(OpenStruct.new(title: ["value1", "value2", "", ""]))
+      expect(result["result"]).to eq(["value1", "value2"])
+    end
+
+    it "ignores all empty string value" do
+      result = indexer.map_record(OpenStruct.new(title: ["", ""]))
+      expect(result["result"]).to be_nil
+      expect(result.keys).not_to include("result")
+    end
   end
 
   describe "model attribute" do
@@ -62,6 +79,12 @@ describe "ObjExtract traject macro" do
     it "indexes nil without raising" do
       result = indexer.map_record(OpenStruct.new(creator: nil))
       expect(result).to eq({})
+    end
+
+    it "ignores empty string" do
+      result = indexer.map_record(OpenStruct.new(creator: OpenStruct.new(type: "engraver", name: "")))
+      expect(result["result"]).to be_nil
+      expect(result.keys).not_to include("result")
     end
 
     describe "as array" do
@@ -83,6 +106,12 @@ describe "ObjExtract traject macro" do
           ])
         )
         expect(result).to eq({ "result" => ["Joe Shmoe", "Mary Sue"]})
+      end
+
+      it "ignores empty string" do
+        result = indexer.map_record(OpenStruct.new(creator: [OpenStruct.new(type: "engraver", name: "")]))
+        expect(result["result"]).to be_nil
+        expect(result.keys).not_to include("result")
       end
     end
 
@@ -123,6 +152,11 @@ describe "ObjExtract traject macro" do
       result = indexer.map_record(OpenStruct.new(creator: []))
       expect(result).to eq({})
     end
-  end
 
+    it "ignores empty string" do
+      result = indexer.map_record(OpenStruct.new(creator: {type: "engraver", name: ""}))
+      expect(result["result"]).to be_nil
+      expect(result.keys).not_to include("result")
+    end
+  end
 end


### PR DESCRIPTION
Typical Rails form submission patterns can result in empty strings (`""`) winding up stored in your model attributes in db.

For most purposes, an empty string indexed to solr is going to be useless or harmful -- for tokenized fields it'll end up getting pretty much ignored (or doing weird unintended things to matching and tf-idf), for non-tokenized fields used for faceting, you get an empty string facet which most UIs are going to do odd things with.

Since it's unlikely to be desired/useful, but Rails patterns make it fairly likely to happen -- obj_extract should just filter them out, and treat empty strings as if they were nil, and remove them from array values too. Rather than require apps to put custom configuration on (possibly per-indexing-rule!) to remove empty strings and keep them from messing up the index. (I ran into this with facet values).

While I can hypothetically think of use cases where you might want an empty string (samvera/valkyrie style "round-trippable" storage to Solr -- athough not positive even there), they are not the use cases kithe or obj_extract are focused on, and I think are unlikely to come up, and it's fine to simply make obj_extract do this.

@ebenenglish FYI, and curious if you have thoughts?