### PR TITLE
obj_extract allows `false` values to be generated

### DIFF
--- a/app/indexing/kithe/indexer/obj_extract.rb
+++ b/app/indexing/kithe/indexer/obj_extract.rb
@@ -59,9 +59,9 @@ module Kithe
           nil
         elsif rest.empty?
           if result.kind_of?(Array)
-            result.collect(&:presence).compact # remove empty string and nil
+            result.collect { |v| v == "" ? nil : v  }.compact # remove empty string and nil
           else
-            result.presence # turn empty strings to nil
+            result == "" ? nil : result # turn empty strings to nil
           end
         else
           # recurse

--- a/spec/indexing/obj_extract_spec.rb
+++ b/spec/indexing/obj_extract_spec.rb
@@ -28,6 +28,11 @@ describe "ObjExtract traject macro" do
       expect(result["result"]).to be_nil
       expect(result.keys).not_to include("result")
     end
+
+    it "indexes false" do
+      result = indexer.map_record(OpenStruct.new(title: false))
+      expect(result["result"]).to eq([false])
+    end
   end
 
   describe "primitive array attribute" do
@@ -61,6 +66,11 @@ describe "ObjExtract traject macro" do
       result = indexer.map_record(OpenStruct.new(title: ["", ""]))
       expect(result["result"]).to be_nil
       expect(result.keys).not_to include("result")
+    end
+
+    it "allows false values" do
+      result = indexer.map_record(OpenStruct.new(title: [false]))
+      expect(result["result"]).to eq([false])
     end
   end
 


### PR DESCRIPTION
Using Rails #presence to elminate empty strings was too aggressive, eliminated boolean false too, which we didn't mean to!

too aggressive in https://github.com/sciencehistory/kithe/pull/70

Causing problem in our app: https://github.com/sciencehistory/scihist_digicoll/issues/521