### PR TITLE
allow repeatable_attr_input to take custom simple form input args to pass to simple_form #input

### DIFF
--- a/app/simple_form_enhancements/kithe/form_builder.rb
+++ b/app/simple_form_enhancements/kithe/form_builder.rb
@@ -34,8 +34,13 @@ class Kithe::FormBuilder < SimpleForm::FormBuilder
   # @yieldparam [String] input_name  that should be used as HTML "name" attribute on input
   # @yieldparam [String] value that should be used as existing value when generating input for
   #   primitive, usually by passing to `value` attribute in some input builder.
-  def repeatable_attr_input(attr_name, html_attributes: nil, build: nil, &block)
+  # @yieldparam [Hash] hash of additional keyword args to pass to underlying simple_form
+  #    #input method. Eg `required`.
+  def repeatable_attr_input(attr_name, html_attributes: nil, build: nil, simple_form_input_args: {},  &block)
     #repeatable_main_content(attr_name, &block)
-    Kithe::RepeatableInputGenerator.new(self, attr_name, block, html_attributes: html_attributes, build: build).render
+    Kithe::RepeatableInputGenerator.new(self, attr_name, block,
+      html_attributes: html_attributes,
+      simple_form_input_args: simple_form_input_args,
+      build: build).render
   end
 end

--- a/app/simple_form_enhancements/kithe/repeatable_input_generator.rb
+++ b/app/simple_form_enhancements/kithe/repeatable_input_generator.rb
@@ -5,17 +5,18 @@
 #
 # FUTURE: more args to customize classses and labels.
 class Kithe::RepeatableInputGenerator
-  attr_reader :form_builder, :attribute_name, :html_attributes
+  attr_reader :form_builder, :attribute_name, :html_attributes, :simple_form_input_args
   # the block that captures what the caller wants to be repeatable content.
   # It should take one block arg, a form_builder.
   attr_reader :caller_content_block
 
-  def initialize(form_builder, attribute_name, caller_content_block, primitive: nil, html_attributes: nil, build: nil)
+  def initialize(form_builder, attribute_name, caller_content_block, primitive: nil, html_attributes: nil, build: nil, simple_form_input_args: {})
     @form_builder = form_builder
     @attribute_name = attribute_name
     @caller_content_block = caller_content_block
     @primitive = primitive
     @html_attributes = html_attributes
+    @simple_form_input_args = simple_form_input_args
 
     unless attr_json_registration && attr_json_registration.type.is_a?(AttrJson::Type::Array)
       raise ArgumentError, "can only be used with attr_json-registered attributes"
@@ -47,7 +48,7 @@ class Kithe::RepeatableInputGenerator
     end
 
     # simple_form #input method, with a block for custom input content.
-    form_builder.input(attribute_name, wrapper: :vertical_collection) do
+    form_builder.input(attribute_name, wrapper: :vertical_collection, **simple_form_input_args) do
       template.safe_join([
         placeholder_hidden_input,
         existing_value_inputs,

--- a/spec/simple_form_enhancements/repeatable_input_generator_spec.rb
+++ b/spec/simple_form_enhancements/repeatable_input_generator_spec.rb
@@ -163,6 +163,22 @@ describe Kithe::RepeatableInputGenerator, type: :helper do
         end
       end
     end
+
+    describe "specified simple_form_input_arg required" do
+      let(:instance) { TestWork.new }
+
+      let(:generator) do
+        generator = nil
+        helper.simple_form_for(instance, url: "http://example/target") do |form|
+          generator = Kithe::RepeatableInputGenerator.new(form, :multi_model, block, simple_form_input_args: { required: true })
+        end
+        generator
+      end
+
+      it "outputs as required" do
+        assert_select("abbr[title='required']")
+      end
+    end
   end
 
   describe "for a repeated primitive string" do


### PR DESCRIPTION
in our app we are using to override/force a required setting.