### PR TITLE
Don't call set_leaf_representative on save if it's been explicitly set to a new value already

### DIFF
--- a/app/models/kithe/model.rb
+++ b/app/models/kithe/model.rb
@@ -57,7 +57,9 @@ class Kithe::Model < ActiveRecord::Base
   # loading on hetereogenous fetches
   belongs_to :representative, class_name: "Kithe::Model", optional: true
   belongs_to :leaf_representative, class_name: "Kithe::Model", optional: true
-  before_save :set_leaf_representative, if: ->(model) { model.will_save_change_to_representative_id? }
+  # If representative has changed, and the caller isn't manually changing leaf_representative,
+  # then re-calculate it.
+  before_save :set_leaf_representative, if: ->(model) { model.will_save_change_to_representative_id? && !model.will_save_change_to_leaf_representative_id? }
 
   after_save :update_referencing_leaf_representatives
   before_destroy :nullify_representative_ids

--- a/spec/models/kithe/representatives_spec.rb
+++ b/spec/models/kithe/representatives_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Model representatives", type: :model do
     let(:work) { FactoryBot.create(:kithe_work, title: "top", representative: intermediate_work)}
     let(:intermediate_work) { FactoryBot.create(:kithe_work, title: "intermediate", representative: asset)}
 
-    it "is set" do
+    it "is automatically set" do
       expect(intermediate_work.leaf_representative).to eq(asset)
       expect(work.leaf_representative).to eq(asset)
 
@@ -34,7 +34,23 @@ RSpec.describe "Model representatives", type: :model do
       expect(work.leaf_representative).to be(nil)
     end
 
-    it "can be set if wrong" do
+    it "is not automatically set if you are manually setting it" do
+      expect(work).not_to receive(:set_leaf_representative)
+
+      work.representative = asset
+      work.leaf_representative = intermediate_work
+      work.save!
+
+
+
+      # it's wrong, but we set it intentionally. The actual use
+      # case is when we're setting it to something RIGHT, and want to
+      # avoid the extra work of the automatic lookup, cause we're setting it.
+      # Or when we're doing bulk data imports etc.
+      expect(work.leaf_representative_id).to eq(intermediate_work.id)
+    end
+
+    it "set_leaf_representative can fix wrong value" do
       wrong_asset = FactoryBot.create(:kithe_asset)
       work.update(leaf_representative_id: wrong_asset.id)
 


### PR DESCRIPTION
Got in the way of our bulk imports, if we're bulk importing and setting leaf_representative_id, we don't need the logic to look it up to be called. And in some cases, when we were trying to defer enforcing of constraints and set to an id that isn't in db yet -- the automaticc lookup was setting to nil when we were trying to set to a value.