### PR TITLE
test and pass in travis under ruby 2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
  - 2.5.3
+ - 2.7.0
 before_install:
   - sudo apt-get install -y libvips-tools
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,7 @@ addons:
 gemfile:
   - gemfiles/rails_52.gemfile
   - gemfiles/rails_60.gemfile
+jobs:
+  exclude:
+    - rvm: 2.7.0
+      gemfile: gemfiles/rails_52.gemfile

--- a/kithe.gemspec
+++ b/kithe.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency "traject", "~> 3.0", ">= 3.1.0.rc1" # for Solr or other indexing
   s.add_dependency "rsolr", "~> 2.2" # for some low-level solr stuff
 
+
   s.add_development_dependency "appraisal" # CI testing under multiple rails versions
   s.add_development_dependency "dimensions" # checking image width of transformers in tests
 
@@ -41,4 +42,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "yard-activesupport-concern"
   s.add_development_dependency "shrine-memory"
   s.add_development_dependency "webmock", "~> 3.0"
+  s.add_development_dependency 'sane_patch', "< 2"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -125,4 +125,14 @@ end
 
 
 
+require 'shrine/storage/memory'
+class Shrine::Storage::Memory
+  def open(id, *)
+    str = store.fetch(id)
+    StringIO.new(str).set_encoding(str.encoding, str.encoding)
+  end
+end
+
+
+
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -123,16 +123,22 @@ RSpec.configure do |config|
 =end
 end
 
-
-
-require 'shrine/storage/memory'
-class Shrine::Storage::Memory
-  def open(id, *)
-    str = store.fetch(id)
-    StringIO.new(str).set_encoding(str.encoding, str.encoding)
+# Workaround ruby 2.7.0 StringIO enccoding weirdness, which hopefully
+# will be fixed in shrine 3.x before we get there. if you can remove this patch
+# and tests still pass, you're good.
+#
+# https://github.com/shrinerb/shrine/pull/443
+#
+require 'sane_patch'
+SanePatch.patch("shrine", "< 3") do
+  require 'shrine/storage/memory'
+  class Shrine::Storage::Memory
+    def open(id, *)
+      str = store.fetch(id)
+      StringIO.new(str).set_encoding(str.encoding, str.encoding)
+    end
   end
 end
-
 
 
 


### PR DESCRIPTION
Need to apply patch to Shrine::Storage::Memory (which we use in testing for tests), to keep it working properly under ruby 2.7.0, due to likely bug in ruby 2.7.0. 

We are still on shrine 2.0 using Shrine::Storage::Memory from additional gem, so any patches that land in Shrine 3.x we'll never get anyway. But we can patch. 

https://github.com/shrinerb/shrine/pull/443