### PR TITLE
Silence Ruby 2.7.0 kwargs deprecations

### DIFF
--- a/app/indexing/kithe/indexable/thread_settings.rb
+++ b/app/indexing/kithe/indexable/thread_settings.rb
@@ -25,7 +25,7 @@ module Kithe
       # @param (see #initialize)
       def self.push(**kwargs)
         original = Thread.current[THREAD_CURRENT_KEY]
-        instance = new(kwargs.merge(original_settings: original))
+        instance = new(**kwargs.merge(original_settings: original))
         Thread.current[THREAD_CURRENT_KEY] = instance
 
         instance

--- a/app/models/kithe/asset.rb
+++ b/app/models/kithe/asset.rb
@@ -199,7 +199,7 @@ class Kithe::Asset < Kithe::Model
       record: self
     }.merge(context)
 
-    file_attacher.promote(file_attacher.get, context)
+    file_attacher.promote(file_attacher.get, **context)
   end
 
   # The derivative creator sets metadata when it's created all derivatives

--- a/app/models/kithe/config_base.rb
+++ b/app/models/kithe/config_base.rb
@@ -114,6 +114,12 @@ module Kithe
     def self.define_key(*args)
       instance.define_key(*args)
     end
+    class << self
+      # https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
+      if RUBY_VERSION >= "2.7"
+        ruby2_keywords :define_key
+      end
+    end
 
     def self.lookup(*args)
       instance.lookup(*args)

--- a/lib/shrine/plugins/kithe_promotion_hooks.rb
+++ b/lib/shrine/plugins/kithe_promotion_hooks.rb
@@ -116,7 +116,7 @@ class Shrine
           # insist on a metadata extraction, add a new key `promoting: true` in case
           # anyone is interested.
 
-          uploaded_file.refresh_metadata!(context.merge(options).merge(promoting: true))
+          uploaded_file.refresh_metadata!(**context.merge(options).merge(promoting: true))
 
           # Now run ordinary promotion with activemodel callbacks from
           # the Asset, which will automatically allow them to cancel promotion using

--- a/spec/test_support/shrine_spec_support.rb
+++ b/spec/test_support/shrine_spec_support.rb
@@ -13,7 +13,7 @@ module ShrineSpecSupport
     uploader = test_uploader(*args, &block)
     Object.send(:remove_const, "TestUser") if defined?(TestUser) # for warnings
     user_class = Object.const_set("TestUser", Struct.new(:avatar_data, :id))
-    user_class.include uploader.class::Attachment.new(:avatar, attachment_options)
+    user_class.include uploader.class::Attachment.new(:avatar, **attachment_options)
     user_class.new.avatar_attacher
   end
 


### PR DESCRIPTION
We think we caught all of the ones caused by our code. Although it's possible we missed some. Because there are still a lot of deprecation notices caused by Rails and other dependencies that we can't do anything about for now.