### PR TITLE
Rescue from ActiveJob::DeserializationError during derivative creation.

### DIFF
--- a/app/jobs/kithe/create_derivatives_job.rb
+++ b/app/jobs/kithe/create_derivatives_job.rb
@@ -1,12 +1,13 @@
 module Kithe
   class CreateDerivativesJob < Job
     def perform(asset, mark_created: nil)
-      begin
         asset.create_derivatives(mark_created: mark_created)
-      rescue ActiveJob::DeserializationError
-        Rails.logger.error("Unable to derivatives for asset with ID #{asset.id}, as it was deleted first.")
-        return
-      end
+    end
+    # This error typically occurs when several large assets, whose derivatives
+    # take a long time to generate, are deleted immediately after ingest.
+    rescue_from(ActiveJob::DeserializationError) do |exception|
+      Rails.logger.error("Unable to derivatives for this asset, as it was unavailable.")
+      Rails.logger.error("Details: #{exception.inspect}")
     end
   end
 end

--- a/app/jobs/kithe/create_derivatives_job.rb
+++ b/app/jobs/kithe/create_derivatives_job.rb
@@ -6,8 +6,7 @@ module Kithe
     # This error typically occurs when several large assets, whose derivatives
     # take a long time to generate, are deleted immediately after ingest.
     rescue_from(ActiveJob::DeserializationError) do |exception|
-      Rails.logger.error("Unable to derivatives for this asset, as it was unavailable.")
-      Rails.logger.error("Details: #{exception.inspect}")
+      Rails.logger.error("Unable to create derivatives for this asset, as it was unavailable. Details: #{exception}")
     end
   end
 end

--- a/app/jobs/kithe/create_derivatives_job.rb
+++ b/app/jobs/kithe/create_derivatives_job.rb
@@ -1,7 +1,12 @@
 module Kithe
   class CreateDerivativesJob < Job
     def perform(asset, mark_created: nil)
-      asset.create_derivatives(mark_created: mark_created)
+      begin
+        asset.create_derivatives(mark_created: mark_created)
+      rescue ActiveJob::DeserializationError
+        Rails.logger.error("Unable to derivatives for asset with ID #{asset.id}, as it was deleted first.")
+        return
+      end
     end
   end
 end

--- a/app/jobs/kithe/create_derivatives_job.rb
+++ b/app/jobs/kithe/create_derivatives_job.rb
@@ -6,7 +6,7 @@ module Kithe
     # This error typically occurs when several large assets, whose derivatives
     # take a long time to generate, are deleted immediately after ingest.
     rescue_from(ActiveJob::DeserializationError) do |exception|
-      Rails.logger.error("Unable to create derivatives for this asset, as it was unavailable. Details: #{exception}")
+      Rails.logger.error("Kithe::CreateDerivativesJob: Unable to create derivatives for this asset, as it was unavailable. Details: #{exception}")
     end
   end
 end

--- a/lib/kithe/version.rb
+++ b/lib/kithe/version.rb
@@ -1,3 +1,3 @@
 module Kithe
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end

--- a/spec/models/kithe/asset/asset_create_derivatives_spec.rb
+++ b/spec/models/kithe/asset/asset_create_derivatives_spec.rb
@@ -50,6 +50,27 @@ describe "Kithe::Asset derivative definitions", queue_adapter: :test do
     expect(asset.derivatives_created?).to be(true)
   end
 
+
+  describe "Original deleted before derivatives can be created", queue_adapter: :inline do
+    let(:short_lived_asset) do
+      TestAssetSubclass.create!(title: "test",
+        file: File.open(Kithe::Engine.root.join("spec/test_support/images/1x1_pixel.jpg")))
+    end
+    it """catches the ActiveJob::DeserializationError
+      if the asset is no longer in the database
+      once the derivative creation job starts up.""" do
+      id_to_delete = short_lived_asset.id
+      Kithe::Derivative.where(asset_id: id_to_delete).delete_all
+      Kithe::Model.where(id: id_to_delete).delete_all
+
+      # short_lived_asset is no longer in the DB.
+      # Let's try and create derivatives for it:
+      expect do
+        Kithe::CreateDerivativesJob.perform_later(short_lived_asset)
+      end.not_to raise_error
+    end
+  end
+
   describe "under normal operation", queue_adapter: :inline do
     let(:asset) do
       TestAssetSubclass.create!(title: "test",


### PR DESCRIPTION
Ref https://github.com/sciencehistory/scihist_digicoll/issues/577 .
Includes a test. Thanks, @jrochkind, for excellent pointers on how to deal with this.