### PR TITLE
Extract any logic in our Kithe::AssetUploader to a shrine plugin

### DIFF
--- a/app/uploaders/kithe/asset_uploader.rb
+++ b/app/uploaders/kithe/asset_uploader.rb
@@ -34,24 +34,7 @@ module Kithe
     # promotion, possibly in the background.
     plugin :refresh_metadata
 
-    # Marcel analyzer is pure-ruby and fast. It's from Basecamp and is what
-    # ActiveStorage uses. It is very similar to :mimemagic (and uses mimemagic
-    # under the hood), but mimemagic seems not to be maintained with up to date
-    # magic db? https://github.com/minad/mimemagic/pull/66
-    plugin :determine_mime_type, analyzer: -> (io, analyzers) do
-      mime_type = analyzers[:marcel].call(io)
-
-      # But marcel is not able to catch some of our MP3s as audio/mpeg,
-      # let's try mediainfo command line. mediainfo is one of the tools
-      # the Harvard Fits tool uses. https://github.com/MediaArea/MediaInfo
-      if Kithe.use_mediainfo && mime_type == "application/octet-stream" || mime_type.blank?
-        mime_type = Kithe::MediainfoAnalyzer.new.call(io)
-      end
-
-      mime_type = "application/octet-stream" if mime_type.blank?
-
-      mime_type
-    end
+    plugin :kithe_determine_mime_type
 
     # Will save height and width to metadata for image types. (Won't for non-image types)
     # ignore errors (often due to storing a non-image file), consistent with shrine 2.x behavior.

--- a/app/uploaders/kithe/asset_uploader.rb
+++ b/app/uploaders/kithe/asset_uploader.rb
@@ -47,8 +47,6 @@ module Kithe
     # Set up logic for backgrounding, which can be set by promotion_directives
     plugin :kithe_controllable_backgrounding
 
-    plugin :add_metadata
-
     # Makes files stored as /asset/#{asset_pk}/#{random_uuid}.#{original_suffix}
     plugin :kithe_storage_location
 
@@ -58,24 +56,10 @@ module Kithe
     # WARNING: There's no whitelist, will accept any url. Is this a problem?
     plugin :kithe_accept_remote_url
 
-    # We want to store md5 and sha1 checksums (legacy compat), as well as
-    # sha512 (more recent digital preservation recommendation: https://ocfl.io/draft/spec/#digests)
-    #
-    # We only calculate them on `store` action to avoid double-computation, and because for
-    # direct uploads/backgrounding, we haven't actually gotten the file in our hands to compute
-    # checksums until then anyway.
-    plugin :signature
-    add_metadata do |io, context|
-      if context[:action] != :cache
-        {
-          md5: calculate_signature(io, :md5),
-          sha1: calculate_signature(io, :sha1),
-          sha512: calculate_signature(io, :sha512)
-        }
-      end
-    end
-    metadata_method :md5, :sha1, :sha512
 
+    # Ensures md5, sha1, and sha512 are stored as metadata, calculated on promotion.
+    # sha512 is used by other shrine logic as a fingerprint of identity.
+    plugin :kithe_checksum_signatures
 
     # Gives us (set_)promotion_directives methods on our attacher to
     # house lifecycle directives, about whether promotion, deletion,

--- a/app/uploaders/kithe/asset_uploader.rb
+++ b/app/uploaders/kithe/asset_uploader.rb
@@ -64,7 +64,7 @@ module Kithe
     #      /asset/#{asset_pk}/#{random_uuid}.#{original_suffix}
     plugin :kithe_storage_location
 
-    # Set up logic for backgrounding, which can be set by promotion_directives
+    # Set up logic for shrine backgrounding, which in kithe can be set by promotion_directives
     plugin :kithe_controllable_backgrounding
 
     # Gives us (set_)promotion_directives methods on our attacher to
@@ -72,6 +72,7 @@ module Kithe
     # derivatives happen in foreground, background, or not at all.
     plugin :kithe_promotion_directives
 
+    # Makes our before/after promotion callbacks get called.
     plugin :kithe_promotion_callbacks
   end
 end

--- a/lib/shrine/plugins/kithe_checksum_signatures.rb
+++ b/lib/shrine/plugins/kithe_checksum_signatures.rb
@@ -1,0 +1,41 @@
+class Shrine
+  module Plugins
+    # Using the shrine signature and add_metadata plugins, ensure that the shrine standard
+    # digest/checksum signatures are recorded in metadata.
+    #
+    # We want to store md5 and sha1 checksums (legacy compat), as well as
+    # sha512 (more recent digital preservation recommendation: https://ocfl.io/draft/spec/#digests)
+    #
+    # The sha512 is required by other kithe logic which uses it as a fingerprint to know when
+    # an asset has changed.
+    #
+    # We only calculate them only on promotion action (not cache action), to avoid needlessly
+    # expensive double-computation, and because for direct uploads/backgrounding, we haven't
+    # actually gotten the file in our hands to compute checksums until then anyway.
+    #
+    # the add_metadata plugin's `metadata_method` is used to make md5, sha1, and sha512 methods
+    # available on the Attacher. (They also end up delegated from the Asset model)
+    class KitheChecksumSignatures
+      def self.load_dependencies(uploader, *)
+        uploader.plugin :add_metadata
+        uploader.plugin :signature
+      end
+
+      def self.configure(uploader, opts = {})
+        uploader.class_eval do
+          add_metadata do |io, context|
+            if context[:action] != :cache
+              {
+                md5: calculate_signature(io, :md5),
+                sha1: calculate_signature(io, :sha1),
+                sha512: calculate_signature(io, :sha512)
+              }
+            end
+          end
+          metadata_method :md5, :sha1, :sha512
+        end
+      end
+    end
+    register_plugin(:kithe_checksum_signatures, KitheChecksumSignatures)
+  end
+end

--- a/lib/shrine/plugins/kithe_controllable_backgrounding.rb
+++ b/lib/shrine/plugins/kithe_controllable_backgrounding.rb
@@ -19,6 +19,7 @@ class Shrine
     class KitheControllableBackgrounding
       def self.load_dependencies(uploader, *)
         uploader.plugin :backgrounding
+        uploader.plugin :kithe_promotion_directives
       end
 
       def self.configure(uploader, options = {})

--- a/lib/shrine/plugins/kithe_controllable_backgrounding.rb
+++ b/lib/shrine/plugins/kithe_controllable_backgrounding.rb
@@ -1,0 +1,52 @@
+class Shrine
+  module Plugins
+
+    # Set up shrine `backgrounding`, where promotion and deletion can happen in a background job.
+    #
+    # https://shrinerb.com/docs/getting-started#backgrounding
+    # https://shrinerb.com/docs/plugins/backgrounding
+    #
+    # By default, kithe does promotion and deletion in kithe-provided ActiveJob classes.
+    #
+    # But this plugin implements code to let you use kithe_promotion_directives to make them happen
+    # inline instead, or disable them.
+    #
+    #     asset.file_attacher.set_promotion_directives(promote: false)
+    #     asset.file_attacher.set_promotion_directives(promote: :inline)
+    #     asset.file_attacher.set_promotion_directives(promote: "inline")
+    #
+    #     asset.file_attacher.set_promotion_directives(delete: :inline)
+    class KitheControllableBackgrounding
+      def self.load_dependencies(uploader, *)
+        uploader.plugin :backgrounding
+      end
+
+      def self.configure(uploader, options = {})
+
+        # promote using shrine backgrounding, but can be effected by promotion_directives[:promote]
+        uploader::Attacher.promote_block do
+          Kithe::TimingPromotionDirective.new(key: :promote, directives: self.promotion_directives) do |directive|
+            if directive.inline?
+              promote
+            elsif directive.background?
+              # What shrine normally expects for backgrounding, plus promotion_directives
+              Kithe::AssetPromoteJob.perform_later(self.class.name, record.class.name, record.id, name.to_s, file_data, self.promotion_directives)
+            end
+          end
+        end
+
+        uploader::Attacher.destroy_block do
+          Kithe::TimingPromotionDirective.new(key: :delete, directives: self.promotion_directives) do |directive|
+            if directive.inline?
+              destroy
+            elsif directive.background?
+              # What shrine normally expects for backgrounding
+              Kithe::AssetDeleteJob.perform_later(self.class.name, data)
+            end
+          end
+        end
+      end
+    end
+    register_plugin(:kithe_controllable_backgrounding, KitheControllableBackgrounding)
+  end
+end

--- a/lib/shrine/plugins/kithe_determine_mime_type.rb
+++ b/lib/shrine/plugins/kithe_determine_mime_type.rb
@@ -1,0 +1,39 @@
+class Shrine
+  module Plugins
+    # Custom kithe logic for determining mime type, using the shrine mime_type plugin.
+    #
+    # We start out using the `marcel` analyzer.
+    # Marcel analyzer is pure-ruby and fast. It's from Basecamp and is what
+    # ActiveStorage uses. It is very similar to :mimemagic (and uses mimemagic
+    # under the hood), but mimemagic seems not to be maintained with up to date
+    # magic db? https://github.com/minad/mimemagic/pull/66
+    #
+    # But marcel is not able to catch some of our MP3s as audio/mpeg. The
+    # `mediainfo` CLI is, and is one of the tools Harvard FITS uses.
+    # If marcel came up blank, AND we are configured to use mediainfo CLI
+    # (which by default we will be if it's available), we will try
+    # shelling out to mediainfo command line.
+    #
+    # https://github.com/MediaArea/MediaInfo
+    #
+    # Ensure that if mime-type can't be otherwise determined, it is assigned
+    # "application/octet-stream", basically the type for generic binary.
+    class KitheDetermineMimeType
+      def self.load_dependencies(uploader, *)
+        uploader.plugin :determine_mime_type, analyzer: -> (io, analyzers) do
+          mime_type = analyzers[:marcel].call(io)
+
+
+          if Kithe.use_mediainfo && mime_type == "application/octet-stream" || mime_type.blank?
+            mime_type = Kithe::MediainfoAnalyzer.new.call(io)
+          end
+
+          mime_type = "application/octet-stream" if mime_type.blank?
+
+          mime_type
+        end
+      end
+    end
+    register_plugin(:kithe_determine_mime_type, KitheDetermineMimeType)
+  end
+end

--- a/lib/shrine/plugins/kithe_promotion_callbacks.rb
+++ b/lib/shrine/plugins/kithe_promotion_callbacks.rb
@@ -24,6 +24,11 @@ class Shrine
     # was convenient and avoided confusion to isolate wrapping in a class method that can be used
     # anywhere, and only depends on args passed in, no implicit state anywhere.
     class KithePromotionCallbacks
+      def self.load_dependencies(uploader, *)
+        uploader.plugin :kithe_promotion_directives
+      end
+
+
       # promotion logic differs somewhat in different modes of use (bg or inline promotion),
       # so we extract the wrapping logic here. Exactly what the logic wrapped is can
       # differ.


### PR DESCRIPTION
Make it more easier to in the future create a custom shrine uploader re-using exactly what you want. no more or no less, by mixing and matching plugins. Just keeps the code a bit more consistent and clean.