### PR TITLE
Kithe::Asset.set_shrine_uploader functionality

### DIFF
--- a/app/models/kithe/asset.rb
+++ b/app/models/kithe/asset.rb
@@ -1,4 +1,6 @@
 class Kithe::Asset < Kithe::Model
+  include Kithe::Asset::SetShrineUploader
+
   has_many :derivatives, foreign_key: "asset_id", inverse_of: "asset", dependent: :destroy # dependent destroy to get shrine destroy logic for assets
 
   # These associations exist for hetereogenous eager-loading, but hide em.

--- a/app/models/kithe/asset/set_shrine_uploader.rb
+++ b/app/models/kithe/asset/set_shrine_uploader.rb
@@ -1,0 +1,64 @@
+# Our Kithe::Asset model class is meant to be a superclass of a local application asset class, which we
+# can call `Asset`, although an app can call it whatever they like.
+#
+# Kithe::Asset sets it's own shrine uploader class, with a typical shrine:
+#
+#     include Kithe::AssetUploader::Attachment(:file)
+#
+# An application Asset subclass will inherit this uploader, which is convenient for getting
+# started quickly. But an application will likely want to define its own local uploader
+# class, to define it's own metadata, derivatives, and any other custom beahvior.
+#
+# There isn't an obvious built-into-shrine way to do that, but it turns out simply overriding
+# class and instance `*_attacher` methods seems to work out well. See:
+# https://discourse.shrinerb.com/t/model-sub-classes-with-uploader-sub-classes/208
+#
+# So a local application can define it's own shrine uploader, which is highly recommended to
+# be a sub-class of Kithe::AssetUploader to ensure it has required and useful
+# Kithe behavior:
+#
+#     # ./app/uploaders/asset_uploader.rb
+#     class AssetUploader < Kithe::AssetUploader
+#       # maybe we want some custom metadata
+#       add_metadata :something do |io|
+#         whatever
+#       end
+#     end
+#
+# And then set it in ti's custom local Asset class:
+#
+#     # ./app/models/asset.rb
+#     class Asset < Kithe::Asset
+#       set_shrine_uploader(AssetUploader)
+#     end
+#
+# If a local app has it's own inheritance hieararchy of children below that (eg) Asset class,
+# they can each (optionally) also override with a custom Uploader. It is recommended that
+# the Uploader inheritance hieararchy match the model inheritance hieararchy, to have
+# all behavior consistent. For instance:
+#
+#     class AudioAssetUploader < AssetUploader
+#     end
+#
+#     class AudioAsset < Asset
+#       set_shrine_uploader(AudioAssetUploader)
+#     end
+#
+module Kithe::Asset::SetShrineUploader
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def set_shrine_uploader(uploader_class)
+      subclass_attachment = uploader_class::Attachment.new(:file)
+
+      define_singleton_method :file_attacher do |**options|
+        subclass_attachment.send(:class_attacher, **options)
+      end
+
+      define_method :file_attacher do |**options|
+        subclass_attachment.send(:attacher, self, **options)
+      end
+    end
+  end
+
+end

--- a/spec/models/kithe/asset/set_shrine_uploader_spec.rb
+++ b/spec/models/kithe/asset/set_shrine_uploader_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe Kithe::Asset::SetShrineUploader do
+  temporary_class("MyUploaderSubclass") do
+    Class.new(Kithe::AssetUploader) do
+      add_metadata :uploader_class_name do |io|
+        self.class.name
+      end
+    end
+  end
+
+  temporary_class("AssetSubclass") do
+    Class.new(Kithe::Asset) do
+      set_shrine_uploader(MyUploaderSubclass)
+    end
+  end
+
+  let(:asset) { AssetSubclass.create!(title: "test") }
+  let(:image_path) { Kithe::Engine.root.join("spec/test_support/images/1x1_pixel.jpg") }
+
+  it "has proper class attacher" do
+    expect(AssetSubclass.file_attacher.class).to eq(MyUploaderSubclass::Attacher)
+  end
+
+  it "has proper instance attacher" do
+    expect(asset.file_attacher.class).to eq(MyUploaderSubclass::Attacher)
+  end
+
+  it "can attach file using custom subclass" do
+    asset.set_promotion_directives(promote: :inline)
+    asset.file = File.open(image_path)
+    asset.save!
+    asset.reload
+
+    expect(asset.stored?).to eq(true)
+    expect(asset.file).to be_present
+    expect(asset.file.metadata["uploader_class_name"]).to eq("MyUploaderSubclass")
+  end
+end


### PR DESCRIPTION
To conveniently set specific shrine Uploader class on sub-classes of Kithe::Asset

Ref #81. 

See https://discourse.shrinerb.com/t/model-sub-classes-with-uploader-sub-classes/208