### PR TITLE
make KitheChecksumSignatures optional, and have it refrain from calculating for derivatives

### DIFF
--- a/app/uploaders/kithe/asset_uploader.rb
+++ b/app/uploaders/kithe/asset_uploader.rb
@@ -47,8 +47,8 @@ module Kithe
     # kithe-standard logic for sniffing mime type.
     plugin :kithe_determine_mime_type
 
-    # Ensures md5, sha1, and sha512 are stored as metadata, calculated on promotion.
-    plugin :kithe_checksum_signatures
+    # Just leave it here for otheres please
+    plugin :add_metadata
 
     # Allows you to assign hashes with key "remote_url" to trigger fetch of
     # arbitrary url to assign to Asset. Eg:

--- a/lib/shrine/plugins/kithe_checksum_signatures.rb
+++ b/lib/shrine/plugins/kithe_checksum_signatures.rb
@@ -3,11 +3,11 @@ class Shrine
     # Using the shrine signature and add_metadata plugins, ensure that the shrine standard
     # digest/checksum signatures are recorded in metadata.
     #
+    # This plugin is NOT included in Kithe::AssetUploader by default, include it in your
+    # local uploader if desired.
+    #
     # We want to store md5 and sha1 checksums (legacy compat), as well as
     # sha512 (more recent digital preservation recommendation: https://ocfl.io/draft/spec/#digests)
-    #
-    # The sha512 is required by other kithe logic which uses it as a fingerprint to know when
-    # an asset has changed.
     #
     # We only calculate them only on promotion action (not cache action), to avoid needlessly
     # expensive double-computation, and because for direct uploads/backgrounding, we haven't
@@ -23,8 +23,8 @@ class Shrine
 
       def self.configure(uploader, opts = {})
         uploader.class_eval do
-          add_metadata do |io, context|
-            if context[:action] != :cache
+          add_metadata do |io, derivative:nil, **context|
+            if context[:action] != :cache && derivative.nil?
               {
                 md5: calculate_signature(io, :md5),
                 sha1: calculate_signature(io, :sha1),

--- a/spec/models/kithe/asset/asset_promotion_hooks_spec.rb
+++ b/spec/models/kithe/asset/asset_promotion_hooks_spec.rb
@@ -30,7 +30,6 @@ describe "Kithe::Asset promotion hooks", queue_adapter: :inline do
     it "has access to automatic metadata extraction" do
       unsaved_asset.save!
       expect($metadata_in_before_promotion).to be_present
-      expect($metadata_in_before_promotion['sha512']).to be_present
     end
   end
 
@@ -213,7 +212,6 @@ describe "Kithe::Asset promotion hooks", queue_adapter: :inline do
           asset.reload
 
           expect(asset.stored?).to be(true)
-          expect(asset.sha512).to be_present
         end
       end
 

--- a/spec/models/kithe/asset_spec.rb
+++ b/spec/models/kithe/asset_spec.rb
@@ -51,11 +51,6 @@ RSpec.describe Kithe::Asset, type: :model do
 
       # This is the file location/storage path, currently under UUID pk.
       expect(asset.file.id).to match %r{\Aasset/#{asset.id}/.*\.jpg}
-
-      # checksums
-      expect(asset.sha1).to eq(Digest::SHA1.hexdigest(File.open(source_path).read))
-      expect(asset.md5).to eq(Digest::MD5.hexdigest(File.open(source_path).read))
-      expect(asset.sha512).to eq(Digest::SHA512.hexdigest(File.open(source_path).read))
     end
 
     describe "pdf file" do
@@ -90,11 +85,6 @@ RSpec.describe Kithe::Asset, type: :model do
 
       # This is the file location/storage path, currently under UUID pk.
       expect(asset.file.id).to match %r{\Aasset/#{asset.id}/.*\.jpg}
-
-      # checksums
-      expect(asset.sha1).to eq(Digest::SHA1.hexdigest(File.open(sample_file_path).read))
-      expect(asset.md5).to eq(Digest::MD5.hexdigest(File.open(sample_file_path).read))
-      expect(asset.sha512).to eq(Digest::SHA512.hexdigest(File.open(sample_file_path).read))
     end
   end
 
@@ -144,7 +134,7 @@ RSpec.describe Kithe::Asset, type: :model do
       expect(asset.stored?).to be(true)
       expect(asset.file_attacher.stored?).to be(true)
       expect(asset.file.exists?).to be(true)
-      expect(asset.file.metadata.keys).to include("filename", "size", "mime_type", "width", "height", "md5", "sha1", "sha512")
+      expect(asset.file.metadata.keys).to include("filename", "size", "mime_type", "width", "height")
     end
 
     it "does not do anything for already promoted file", queue_adapter: :inline do

--- a/spec/shrine/kithe_checksum_signatures_spec.rb
+++ b/spec/shrine/kithe_checksum_signatures_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+require 'shrine/plugins/kithe_checksum_signatures'
+
+# This kithe plugin is optional, let's make sure it works how we expect
+describe Shrine::Plugins::KitheChecksumSignatures, queue_adpater: :inline do
+  temporary_class("ChecksumUploader") do
+    Class.new(Kithe::AssetUploader) do
+      plugin :kithe_checksum_signatures
+    end
+  end
+
+  temporary_class("ChecksumAsset") do
+    Class.new(Kithe::Asset) do
+      set_shrine_uploader(ChecksumUploader)
+    end
+  end
+
+  around do |example|
+    original = Kithe::Asset.promotion_directives
+    Kithe::Asset.promotion_directives = { promote: :inline }
+
+    example.run
+
+    Kithe::Asset.promotion_directives = original
+  end
+
+  it "provides checksum metadata after promotion" do
+    asset = ChecksumAsset.create!(title: "test", file: StringIO.new("test"))
+    asset.reload
+
+    expect(asset).to be_stored
+    expect(asset.file.metadata.slice("md5", "sha1", "sha512")).to all(be_present)
+  end
+
+  describe "without promotion" do
+    around do |example|
+      original = Kithe::Asset.promotion_directives
+      Kithe::Asset.promotion_directives = { promote: false }
+
+      example.run
+
+      Kithe::Asset.promotion_directives = original
+    end
+
+    it "does not extract checksum metadata on cache" do
+      asset = ChecksumAsset.create!(title: "test", file: StringIO.new("test"))
+      asset.reload
+
+      expect(asset).not_to be_stored
+      expect(asset.file.metadata.slice("md5", "sha1", "sha512")).not_to include(be_present)
+    end
+  end
+
+  describe "derivatives" do
+    it "do not get checksum metadata" do
+      asset = ChecksumAsset.create!(title: "test", file: StringIO.new("test"))
+      asset.update_derivative("test", StringIO.new("test deriv"))
+
+      expect(asset.file_derivatives[:test]).to be_present
+      expect(asset.file_derivatives[:test].metadata.slice("md5", "sha1", "sha512")).not_to include(be_present)
+    end
+  end
+end


### PR DESCRIPTION
shrine 2.x/kithe 1.x didn't give us checksums for derivatives, we probably don't want to pay the CPU price to calculate it for all of em.

Kithe 2.x no longer relies on checksums for derivative consistency, so no reason we gotta require them, let the app decide which digests they want. We still provide the plugin for plug-and-play implementation of the ones we think you might want.