### PR TITLE
make remove_derivatives plural, more powerful, we already had that in the method we're delegating to.

### DIFF
--- a/app/models/kithe/asset.rb
+++ b/app/models/kithe/asset.rb
@@ -145,8 +145,8 @@ class Kithe::Asset < Kithe::Model
   end
 
   # just a convenience for kithe remove_persisted_derivatives
-  def remove_derivative(key)
-    file_attacher.remove_persisted_derivatives(key)
+  def remove_derivatives(*keys)
+    file_attacher.remove_persisted_derivatives(*keys)
   end
 
   # Runs the shrine promotion step, that we normally have in backgrounding, manually

--- a/spec/models/kithe/asset/asset_derivatives_spec.rb
+++ b/spec/models/kithe/asset/asset_derivatives_spec.rb
@@ -71,7 +71,7 @@ describe "customized shrine derivatives", queue_adapter: :inline do
       asset = CustomAsset.create!(title: "test", file: File.open(original_file_path))
       asset.reload
 
-      asset.remove_derivative(:fixed)
+      asset.remove_derivatives(:fixed)
       expect(asset.file_derivatives.keys).to be_empty
       asset.reload
       expect(asset.file_derivatives.keys).to be_empty


### PR DESCRIPTION
Backwards incompat with shrine 1, that's fine, it was anyway. our local scihist_digicoll app didn't even use this method.