### PR TITLE
Fix default traject logger Rails.logger

### DIFF
--- a/lib/kithe.rb
+++ b/lib/kithe.rb
@@ -68,28 +68,30 @@ module Kithe
   # The settings need to live here not in Kithe::Indexable, to avoid terrible
   # Rails dev-mode class-reloading weirdnesses. This module is not reloaded.
   class << self
-    attr_accessor :indexable_settings
+    attr_writer :indexable_settings
   end
-  self.indexable_settings = IndexableSettings.new(
-    solr_url: "http://localhost:8983/solr/default",
-    model_name_solr_field: "model_name_ssi",
-    solr_id_value_attribute: "id",
-    writer_class_name: "Traject::SolrJsonWriter",
-    writer_settings: {
-      # as default we tell the solrjsonwriter to use no threads,
-      # no batching. softCommit on every update. Least surprising
-      # default configuration.
-      "solr_writer.thread_pool" => 0,
-      "solr_writer.batch_size" => 1,
-      "solr_writer.solr_update_args" => { softCommit: true },
-      "solr_writer.http_timeout" => 3,
-      "logger" => Rails.logger,
+  def self.indexable_settings
+    @indexable_settings ||= IndexableSettings.new(
+      solr_url: "http://localhost:8983/solr/default",
+      model_name_solr_field: "model_name_ssi",
+      solr_id_value_attribute: "id",
+      writer_class_name: "Traject::SolrJsonWriter",
+      writer_settings: {
+        # as default we tell the solrjsonwriter to use no threads,
+        # no batching. softCommit on every update. Least surprising
+        # default configuration.
+        "solr_writer.thread_pool" => 0,
+        "solr_writer.batch_size" => 1,
+        "solr_writer.solr_update_args" => { softCommit: true },
+        "solr_writer.http_timeout" => 3,
+        "logger" => Rails.logger,
 
-      # MAYBE? no skippable exceptions please
-      # "solr_writer.skippable_exceptions" => []
-    },
-    disable_callbacks: false
-  )
+        # MAYBE? no skippable exceptions please
+        # "solr_writer.skippable_exceptions" => []
+      },
+      disable_callbacks: false
+    )
+  end
 
   class << self
     # Currently used by Kithe::AssetUploader, a bit of a hacky

--- a/spec/models/kithe_spec.rb
+++ b/spec/models/kithe_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe "Kithe module" do
+  describe "indexable_settings" do
+    it "gets writer_settings.logger set to Rails.logger" do
+      expect(Rails.logger).not_to be_nil
+      expect(Kithe.indexable_settings.writer_settings["logger"]).to be(Rails.logger)
+    end
+  end
+end


### PR DESCRIPTION
It was looking up before Rails.logger was set, by making it lazy load with memoize, by the time it's looked up Rails seems to be ready. Deosn't feel totally under control, but works good enough for now and has a test taht failed previous but passed with change.