### PR TITLE
change badge to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kithe
 An experiment in shareable tools/components for building a digital collections app in Rails.
 
-[![Build Status](https://travis-ci.org/sciencehistory/kithe.svg?branch=master)](https://travis-ci.org/sciencehistory/kithe)
+[![Build Status](https://travis-ci.com/sciencehistory/kithe.svg?branch=master)](https://travis-ci.com/sciencehistory/kithe)
 [![Gem Version](https://badge.fury.io/rb/kithe.svg)](https://badge.fury.io/rb/kithe)
 
 ## What is kithe?

--- a/gemfiles/rails_60.gemfile
+++ b/gemfiles/rails_60.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", ">= 6.0.0.beta1", "< 6.1"
+gem "rails", ">= 6.0.0", "< 6.1"
 
 group :development, :test do
   gem "rspec-rails", "~> 3.8"


### PR DESCRIPTION
We're moving over, cause travis-ci.org was getting flakey, and we figured out how to migrate