### PR TITLE
Indexing: Allow configurable solr_id_value_attribute values to correctly Solr delete

### DIFF
--- a/app/indexing/kithe/indexable/record_index_updater.rb
+++ b/app/indexing/kithe/indexable/record_index_updater.rb
@@ -44,7 +44,7 @@ module Kithe
             writer.put(context)
           end
         else
-          writer.delete(record.id)
+          writer.delete(record.send(Kithe.indexable_settings.solr_id_value_attribute))
         end
       end
 

--- a/lib/kithe/indexable_settings.rb
+++ b/lib/kithe/indexable_settings.rb
@@ -8,7 +8,7 @@ module Kithe
       @writer_class_name = writer_class_name
       @writer_settings = writer_settings
       @model_name_solr_field = model_name_solr_field
-      @solr_id_value_attribute = solr_id_value_attribute
+      @solr_id_value_attribute = solr_id_value_attribute || 'id'
     end
 
     # Use configured solr_url, and merge together with configured

--- a/spec/indexing/indexable_spec.rb
+++ b/spec/indexing/indexable_spec.rb
@@ -46,7 +46,7 @@ describe Kithe::Indexable, type: :model do
 
         expect(WebMock).to have_requested(:post, @solr_update_url).
           with { |req|
-            JSON.parse(req.body) == { "delete" => work.id }
+            JSON.parse(req.body) == { "delete" => work.send(Kithe.indexable_settings.solr_id_value_attribute) }
           }
       end
     end


### PR DESCRIPTION
Allows a customized solr id field value to delete properly. Will assume solr 'id' field if no configuration value is set.

Fixes: #106