### PR TITLE
Move Kithe::ConfigBase to ./lib/ so it will not be auto-loaded

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 * Indexing: Allow configurable solr_id_value_attribute values to correctly Solr delete. https://github.com/sciencehistory/kithe/pull/109
 
-*
+* Kithe::ConfigBase source file moved to ./lib a rails non-auto-loading location, to make it easier to use in non-deprecating and functioning way from a Rails app config or initialization file, which is one of it's main use cases. https://github.com/sciencehistory/kithe/pull/112
 
 *
 

--- a/lib/kithe/config_base.rb
+++ b/lib/kithe/config_base.rb
@@ -9,7 +9,7 @@ module Kithe
   #
   # You may also want to consider [railsconfig](https://github.com/railsconfig/config)
   #
-  # Kithe::Config:
+  # Kithe::ConfigBase:
   #
   # * uses an explicit declared list of allowable config keys, no silent typos
   # * can read from a local YAML file or ENV, by default letting ENV override local YAML file values.
@@ -97,6 +97,11 @@ module Kithe
   # This doesn't use any locking for concurrent initial loads, which is technically not
   # great, but probably shouldn't be a problem in practice, especially in MRI. Trying to
   # do proper locking with lazy load was too hard for me right now.
+  #
+  # ## Auto-loading
+  #
+  # This is intentionally NOT in an auto-loaded directory, so it can be used more
+  # easily in Rails initialization without problems. https://github.com/rails/rails/issues/40904
   class ConfigBase
     include Singleton
 

--- a/lib/kithe/engine.rb
+++ b/lib/kithe/engine.rb
@@ -11,6 +11,9 @@ require 'shrine'
 require 'fx'
 require 'kithe/patch_fx'
 
+# not auto-loaded, let's just load it for backwards compat though
+require "kithe/config_base"
+
 module Kithe
   class Engine < ::Rails::Engine
     config.generators do |g|


### PR DESCRIPTION
This makes it easier to use in working and non-deprecated way in Rails initialization code, which is one of it's main use cases.

Changes to Rails auto-loading/zeitwerk make it so that you should not be referencing auto-loaded code in Rails configuration/initialization phases.

https://github.com/rails/rails/issues/40904

As we now explicitly require kithe/config_base in the kithe/engine file, this change should be transparent and backwards-compatible.