### PR TITLE
Remove workaround for shrine failure to support lazy download of originals for derivative creation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ## NEXT
 
+### Changed
+
+* Removed hacky workaround to shrine missing func around lazy downloads of originals
+  when procesing derivatives. Can use shrine func `download:false` introduced in shrine 3.3
+  instead. https://github.com/sciencehistory/kithe/pull/122
+
 ## 2.1.0
 
 ### Added

--- a/app/models/kithe/asset.rb
+++ b/app/models/kithe/asset.rb
@@ -81,31 +81,11 @@ class Kithe::Asset < Kithe::Model
     source = file
     return false unless source
 
-    #local_files = file_attacher.process_derivatives(:kithe_derivatives, only: only, except: except, lazy: lazy)
-    local_files = _process_kithe_derivatives_without_download(source, only: only, except: except, lazy: lazy)
+    local_files = file_attacher.process_derivatives(:kithe_derivatives, only: only, except: except, lazy: lazy)
 
     file_attacher.add_persisted_derivatives(local_files)
   end
 
-  # Working around Shrine's insistence on pre-downloading original before calling derivative processor.
-  # We want to avoid that, so when our `lazy` argument is in use, original does not get eagerly downloaded,
-  # but only gets downloaded if needed to make derivatives.
-  #
-  # This is a somewhat hacky way to do that, loking at the internals of shrine `process_derivatives`,
-  # and pulling them out to skip the parts we don't want. We also lose shrine instrumentation
-  # around this action.
-  #
-  # See: https://github.com/shrinerb/shrine/issues/470
-  #
-  # If that were resolved, the 'ordinary' shrine thing would be to replace calls
-  # to this local private method with:
-  #
-  #     file_attacher.process_derivatives(:kithe_derivatives, only: only, except: except, lazy: lazy)
-  #
-  private def _process_kithe_derivatives_without_download(source, **options)
-    processor = file_attacher.class.derivatives_processor(:kithe_derivatives)
-    local_files = file_attacher.instance_exec(source, **options, &processor)
-  end
 
   # Just a convennience for file_attacher.add_persisted_derivatives (from :kithe_derivatives),
   # feel free to use that if you want to add more than one etc.  By default stores to

--- a/kithe.gemspec
+++ b/kithe.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "attr_json", "< 2.0.0"
 
   s.add_dependency "simple_form", ">= 4.0", "< 6.0"
-  s.add_dependency "shrine", "~> 3.2" # file attachment handling
+  s.add_dependency "shrine", "~> 3.3" # file attachment handling
   s.add_dependency "shrine-url", "~> 2.0"
   s.add_dependency "fastimage", "~> 2.0" # use by default for image dimensions
   s.add_dependency "marcel" # use by default for content-type detection

--- a/lib/shrine/plugins/kithe_derivative_definitions.rb
+++ b/lib/shrine/plugins/kithe_derivative_definitions.rb
@@ -10,7 +10,11 @@ class Shrine
 
         # Register our derivative processor, that will create our registered derivatives,
         # with our custom options.
-        uploader::Attacher.derivatives(:kithe_derivatives) do |original, **options|
+        #
+        # We do download: false, so when our `lazy` argument is in use, original does not get eagerly downloaded,
+        # but only gets downloaded if needed to make derivatives. This is great for performance, especially
+        # when running batch job to add just missing derivatives.
+        uploader::Attacher.derivatives(:kithe_derivatives, download: false) do |original, **options|
           Kithe::Asset::DerivativeCreator.new(self.class.kithe_derivative_definitions,
             source_io: original,
             shrine_attacher: self,


### PR DESCRIPTION
Test succesfully failed when we removed workaround WITHOUT adding download:false to derivative processor registration, and then went green when we added download:false. So test seem sto show download:false succesfully replaces our hacky workaround.

Reported in  https://github.com/shrinerb/shrine/issues/470, while my PR https://github.com/shrinerb/shrine/pull/477 looks merged, in fact the commits don't seem to be in shrine repo anymore, I guess they were rewritten? But func is in there. https://github.com/shrinerb/shrine/commit/398a27f01783548856264cf4e3acf3420d169511 . As of shrine 3.3.0, so we update gemspec to require shrine 3.3.