### PR TITLE
Fix docs, define_derivative block takes attacher: param, not record: param

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## NEXT
 
+### Fixed
+
+* Doc-only change, update docs fro kithe 2.0 change to define_derivative block parameter,
+  `attacher:` not `record:`. https://github.com/sciencehistory/kithe/pull/124
+
 ### Added
 
 * Spec and doc custom already-working conditional logic within define_derivative. https://github.com/sciencehistory/kithe/pull/123

--- a/guides/derivatives.md
+++ b/guides/derivatives.md
@@ -108,14 +108,14 @@ end
 
 If multiple derivatives definitions are provided for the same key, only the _most specific_ will be run (content-type with subtype, content-type with primary type only, definition with no content-type).
 
-If you need more complicated conditional logic, you can just put it in a single derivative definition. If your block takes a `record` keyword argument, you can get the Kithe::Asset to query and branch upon.
+If you need more complicated conditional logic, you can just put it in a single derivative definition. If your block takes an `attacher` keyword argument, you will get a `Shrine::Attacher` subclass instance, from which you can call `attacher.record` to get the original Asset model object, or `attacher.file` to get the original file as a `Shrine::UploadedFile` subclass instance.
 
 ```ruby
 class Asset < Kithe::Asset
-  define_derivative(:complicated) do |original_file, record:|
-    if record.content_type == "application/x-my-thing"
+  define_derivative(:complicated) do |original_file, attacher:|
+    if attacher.file.content_type == "application/x-my-thing"
       return io_object
-    elsif record.size < 2.megabytes
+    elsif attacher.file.size < 2.megabytes
       return something_else
     end
     # okay to sometimes return nil
@@ -123,15 +123,15 @@ class Asset < Kithe::Asset
 end
 ```
 
-### custom conditional deriative creation
+### custom conditional derivative creation
 
 If your define_derivative block just returns nil, no derivative will be created. This is a way
 to write whatever logic you want for whether to create a derivative.
 
 ```ruby
-define_derivative(:maybe) do |original_file, record:|
-  if should_create_maybe_deriv?(record)
-    make_maybe_deriv(record)
+define_derivative(:maybe) do |original_file, attacher:|
+  if should_create_maybe_deriv?(attacher.record)
+    make_maybe_deriv(original_file)
   end
 end
 ```

--- a/lib/shrine/plugins/kithe_derivative_definitions.rb
+++ b/lib/shrine/plugins/kithe_derivative_definitions.rb
@@ -48,10 +48,12 @@ class Shrine
         # Tempfile and Dir.mktmpdir may be useful.
         #
         # If in order to do your transformation you need additional information about the original,
-        # just add a `record:` keyword argument to your block, and the Asset object will be passed in:
+        # just add a `attacher:` keyword argument to your block, and a `Shrine::Attacher` subclass
+        # will be passed in. You can then get the model object from `attacher.record`, or the
+        # original file as a `Shrine::UploadedFile` object with `attacher.file`.
         #
-        #     define_derivative :thumbnail do |original_file, record:|
-        #        record.width, record.height, record.content_type # etc
+        #     define_derivative :thumbnail do |original_file, attacher:|
+        #        attacher.record.title, attacher.file.width, attacher.file.content_type # etc
         #     end
         #
         # Derivatives are normally uploaded to the Shrine storage labeled :kithe_derivatives,


### PR DESCRIPTION
This change was made in kithe 2.0, these docs hadn't been updated and were in error. Doc-only commit.