### PR TITLE
Clarify in comment docs where hash literal braces in arguments are required in ruby 3.0

### DIFF
--- a/app/models/kithe/asset.rb
+++ b/app/models/kithe/asset.rb
@@ -124,6 +124,14 @@ class Kithe::Asset < Kithe::Model
     result && result.values.first
   end
 
+  # Like #update_derivative, but can update multiple at once.
+  #
+  #     asset.update_derivatives({ "big_thumb" => big_thumb_io, "small_thumb" => small_thumb_io })
+  #
+  # Options from kithe `add_persisted_derivatives`/shrine `add_derivative` supported.
+  #
+  #     asset.update_derivatives({ "big_thumb" => big_thumb_io, "small_thumb" => small_thumb_io }, delete_false)
+  #
   def update_derivatives(deriv_hash, **options)
     file_attacher.add_persisted_derivatives(deriv_hash, **options)
   end

--- a/lib/shrine/plugins/kithe_persisted_derivatives.rb
+++ b/lib/shrine/plugins/kithe_persisted_derivatives.rb
@@ -26,7 +26,10 @@ class Shrine
         # Like the shrine `add_derivatives` method, but also *persists* the
         # derivatives (saves to db), in a realiably concurrency-safe way.
         #
-        #     attacher.add_persisted_derivatives({ deriv_key1: io1, deriv_key2: io2 })
+        # For ruby 3 compatibility, make sure you supply local_files as a hash
+        # literal with curly braces:
+        #
+        #     attacher.add_persisted_derivatives({ derivative_name1: io_obj1, deriv2: io2 })
         #
         # Generally can take any options that shrine `add_derivatives`
         # can take, including custom `storage` or `metadata` arguments.


### PR DESCRIPTION
shrine-style methods, shrine went through the same thing and just requires hash literal args now without code change, we will do the same to keep matching shrine.