### PR TITLE
test rails 6.1 with ruby 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             ruby: 2.7
 
           - gemfile: rails_61
-            ruby: 2.7
+            ruby: 3.0
 
     name: test ${{ matrix.gemfile }}, ruby ${{ matrix.ruby }}
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 * Doc-only change, update docs fro kithe 2.0 change to define_derivative block parameter,
   `attacher:` not `record:`. https://github.com/sciencehistory/kithe/pull/124
 
+* Ruby 3.0 compatibility.
+
 ### Added
 
 * Spec and doc custom already-working conditional logic within define_derivative. https://github.com/sciencehistory/kithe/pull/123

--- a/app/validators/array_inclusion_validator.rb
+++ b/app/validators/array_inclusion_validator.rb
@@ -42,7 +42,7 @@ class ArrayInclusionValidator < ActiveModel::EachValidator
 
     unless not_allowed_values.blank?
       formatted_rejected = not_allowed_values.uniq.collect(&:inspect).join(",")
-      record.errors.add(attribute, :inclusion, options.except(:in).merge!(rejected_values: formatted_rejected, value: value))
+      record.errors.add(attribute, :inclusion, **options.except(:in).merge!(rejected_values: formatted_rejected, value: value))
     end
   end
 end

--- a/lib/shrine/plugins/kithe_persisted_derivatives.rb
+++ b/lib/shrine/plugins/kithe_persisted_derivatives.rb
@@ -26,6 +26,8 @@ class Shrine
         # Like the shrine `add_derivatives` method, but also *persists* the
         # derivatives (saves to db), in a realiably concurrency-safe way.
         #
+        #     attacher.add_persisted_derivatives({ deriv_key1: io1, deriv_key2: io2 })
+        #
         # Generally can take any options that shrine `add_derivatives`
         # can take, including custom `storage` or `metadata` arguments.
         #

--- a/spec/shrine/kithe_persisted_derivatives_spec.rb
+++ b/spec/shrine/kithe_persisted_derivatives_spec.rb
@@ -28,7 +28,7 @@ describe Shrine::Plugins::KithePersistedDerivatives, queue_adapter: :test do
 
   describe "#add_persisted_derivatives" do
     it "can add and persist" do
-      asset.file_attacher.add_persisted_derivatives(sample: sample_deriv_file!)
+      asset.file_attacher.add_persisted_derivatives({ sample: sample_deriv_file! })
 
       expect(asset.changed?).to be(false)
       expect(asset.file_derivatives[:sample]).to be_present
@@ -74,12 +74,12 @@ describe Shrine::Plugins::KithePersistedDerivatives, queue_adapter: :test do
 
       it "will refuse" do
         expect {
-          asset.file_attacher.add_persisted_derivatives(sample: sample_deriv_file!)
+          asset.file_attacher.add_persisted_derivatives({ sample: sample_deriv_file! })
         }.to raise_error(TypeError)
       end
 
       it "can be forced" do
-        asset.file_attacher.add_persisted_derivatives({sample: sample_deriv_file!}, allow_other_changes: true)
+        asset.file_attacher.add_persisted_derivatives({ sample: sample_deriv_file! }, allow_other_changes: true)
 
         expect(asset.changed?).to be(false)
         asset.reload
@@ -93,7 +93,7 @@ describe Shrine::Plugins::KithePersistedDerivatives, queue_adapter: :test do
 
       it "refuses even with other_changes: true" do
         expect {
-          asset.file_attacher.add_persisted_derivatives({sample: sample_deriv_file!}, allow_other_changes: true)
+          asset.file_attacher.add_persisted_derivatives({ sample: sample_deriv_file! }, allow_other_changes: true)
         }.to raise_error(TypeError)
       end
 
@@ -128,7 +128,7 @@ describe Shrine::Plugins::KithePersistedDerivatives, queue_adapter: :test do
         file = sample_deriv_file!
         local_file_path = file.path
 
-        expect(asset.file_attacher.add_persisted_derivatives(sample: file)).to be(false)
+        expect(asset.file_attacher.add_persisted_derivatives({sample: file})).to be(false)
 
         expect(File.exist?(local_file_path)).to be(false)
       end
@@ -151,7 +151,7 @@ describe Shrine::Plugins::KithePersistedDerivatives, queue_adapter: :test do
         file = sample_deriv_file!
         local_file_path = file.path
 
-        expect(asset.file_attacher.add_persisted_derivatives(new_try: file)).to be(false)
+        expect(asset.file_attacher.add_persisted_derivatives({new_try: file})).to be(false)
 
 
         expect(asset.changed?).to be(false)
@@ -331,10 +331,10 @@ describe Shrine::Plugins::KithePersistedDerivatives, queue_adapter: :test do
 
   describe "#remove_persisted_derivatives" do
     before do
-      asset.file_attacher.add_persisted_derivatives(
+      asset.file_attacher.add_persisted_derivatives({
         sample1: fakeio("sample 1"),
         sample2: fakeio("sample 2")
-      )
+      })
     end
 
     it "can remove" do


### PR DESCRIPTION
We don't need to test every possible ruby version with every rails version, leaving ruby 2.7 with rails 6.0 should be just fine.

Will close #130 once we get it working!