### PR TITLE
Due to a typo in iVar, our Kithe::Indexable.index_with settings weren't properly nesting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 
 * Ruby 3.0 compatibility.
 
+* Fix nested Kithe::Indexable.index_with calls. https://github.com/sciencehistory/kithe/pull/131
+
 ### Added
 
 * Spec and doc custom already-working conditional logic within define_derivative. https://github.com/sciencehistory/kithe/pull/123

--- a/app/indexing/kithe/indexable/thread_settings.rb
+++ b/app/indexing/kithe/indexable/thread_settings.rb
@@ -97,6 +97,8 @@ module Kithe
         # only call on-finish if we have a writer, batch writers are lazily
         # created and maybe we never created one
         if @writer
+          # if we created the writer ourselves locally and nobody
+          # specified an on_finish, close our locally-created writer.
           on_finish = if @local_writer && @on_finish.nil?
             proc {|writer| writer.close }
           else
@@ -105,7 +107,7 @@ module Kithe
           on_finish.call(@writer) if on_finish
         end
 
-        Thread.current[THREAD_CURRENT_KEY] = @original_thread_current_settings
+        Thread.current[THREAD_CURRENT_KEY] = @original_settings
       end
 
       private

--- a/spec/indexing/indexable_spec.rb
+++ b/spec/indexing/indexable_spec.rb
@@ -202,6 +202,22 @@ describe Kithe::Indexable, type: :model do
 
           expect(Thread.current[Kithe::Indexable::ThreadSettings::THREAD_CURRENT_KEY]).to be_nil
         end
+
+        it "can be disabled when there's a nested disable block" do
+          stub_request(:post, @solr_update_url)
+
+          Kithe::Indexable.index_with(disable_callbacks: true) do
+
+            Kithe::Indexable.index_with(disable_callbacks: true) do
+              TestWork.create!(title: "test_a")
+            end
+
+            TestWork.create!(title: "test_b")
+          end
+          expect(WebMock).not_to have_requested(:post, @solr_update_url)
+        end
+
+
       end
 
       describe "specified writer" do


### PR DESCRIPTION
If you nested one within another, they'd be lost in the outer scope, becuase they weren't properly
remembered to pop them.