### PR TITLE
Avoid making a query on every validation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 
-*
+* Avoid making a query on every validation https://github.com/sciencehistory/kithe/pull/134
 
 *
 

--- a/app/models/kithe/validators/model_parent.rb
+++ b/app/models/kithe/validators/model_parent.rb
@@ -1,5 +1,8 @@
 class Kithe::Validators::ModelParent < ActiveModel::Validator
   def validate(record)
+    # don't load the parent just to validate it if it hasn't even changed.
+    return unless record.parent_id_changed?
+
     if record.parent.present? && (record.parent.class <= Kithe::Asset)
       record.errors.add(:parent, 'can not be an Asset instance')
     end
@@ -7,7 +10,5 @@ class Kithe::Validators::ModelParent < ActiveModel::Validator
     if record.parent.present? && record.class <= Kithe::Collection
       record.errors.add(:parent, 'is invalid for Collection instances')
     end
-
-    # TODO avoid recursive parents, maybe using a postgres CTE for efficiency?
   end
 end

--- a/kithe.gemspec
+++ b/kithe.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "appraisal" # CI testing under multiple rails versions
   s.add_development_dependency "dimensions" # checking image width of transformers in tests
 
+  s.add_development_dependency "db-query-matchers", "< 1"
 
   s.add_development_dependency "pg"
   s.add_development_dependency "yard-activesupport-concern"

--- a/spec/models/kithe/work_spec.rb
+++ b/spec/models/kithe/work_spec.rb
@@ -43,6 +43,20 @@ RSpec.describe Kithe::Work, type: :model do
     expect(work.contained_by).to include(collection)
   end
 
+  # this was a problem with we fixed with this originally failing test
+  it "does not do an extra fetch for validation" do
+    work = FactoryBot.create(:kithe_work,
+      parent: FactoryBot.create(:kithe_work),
+      members: [FactoryBot.create(:kithe_work)],
+      contained_by: [FactoryBot.create(:kithe_collection)]).reload
+
+    work.title = "new title"
+
+    expect {
+      work.validate
+    }.not_to make_database_queries
+  end
+
   describe "sub-class with attr_json" do
     let(:subclass_name) { "TestWorkSubclass" }
     let(:subclass) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@
 #
 require 'byebug'
 require 'webmock/rspec'
+require 'db_query_matchers'
 
 RSpec.configure do |config|
 


### PR DESCRIPTION
Leads to a sort of n+1 on batch update. We're going to leave the validation in, but only triggered if the parent has actually changed, no need to run the validation otherwise, so we can skip it and avoid the fetch. If it changed, it is probably already loaded anyway? If not, well, we solved some of the problem here.
