### PR TITLE
Tools for using your own shrine processor with kithe features

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 
 ### Added
 
-*
+* Tools for using a standard shrine derivatives processor with kithe features, including lifecycle management and guard options. https://github.com/sciencehistory/kithe/pull/143
 
 *
 

--- a/app/characterization/kithe/ffprobe_characterization.rb
+++ b/app/characterization/kithe/ffprobe_characterization.rb
@@ -22,6 +22,13 @@ module Kithe
   #
   #     ffprobe_results = FfprobeCharacterization.new(url).ffprobe_hash
   #
+  # The class method .characterize_from_uploader can usefully extract a URL if possible
+  # or else execute with a file, such as from a shrine `add_metadata` block.
+  #
+  #     add_metadata do |source_io, **context|
+  #       Kithe::FfprobeCharacterization.characterize_from_uploader(source_io, context)
+  #     end
+  #
   class FfprobeCharacterization
     class_attribute :ffprobe_command, default: "ffprobe"
     class_attribute :ffprobe_timeout, default: 10

--- a/app/models/kithe/asset.rb
+++ b/app/models/kithe/asset.rb
@@ -43,55 +43,24 @@ class Kithe::Asset < Kithe::Model
   before_promotion :refresh_metadata_before_promotion
   after_promotion :schedule_derivatives
 
-  # A convenience to call file_attacher.create_persisted_derivatives (from :kithe_derivatives)
-  # to create derivatives with conncurrent access safety, with the :kithe_derivatives
-  # processor argument, to create derivatives defined using kithe_derivative_definitions.
+  # Proxies to file_attacher.kithe_create_derivatives to create kithe managed derivatives.
   #
-  # This is designed for use with kithe_derivatives processor, and has options only relevant
-  # to it, although could be expanded to take a processor argument in the future if needed.
+  # This will include any derivatives you created with in the uploader with kithe
+  # Attacher.define_derivative, as well as any derivative processors you opted into
+  # kithe management with `kithe_include_derivatives_processors` in uploader.
   #
-  # Create derivatives for every definition added to uploader/attacher with kithe_derivatives
-  # `define_derivative`. Ordinarily will create a definition for every definition
-  # that has not been marked `default_create: false`.
+  # This is safe for concurrent updates to the underlying model, the derivatives will
+  # be consistent and not left orphaned.
   #
-  # But you can also pass `only` and/or `except` to customize the list of definitions to be created,
-  # possibly including some that are `default_create: false`.
+  # By default it will create all derivatives configured for default generation,
+  # but you can customize by listing derivative keys with :only and :except options,
+  # and with :lazy option which, if true, only executes derivative creation if
+  # a given derivative doesn't already exist.
   #
-  # create_derivatives should be idempotent. If it has failed having only created some derivatives,
-  # you can always just run it again.
-  #
-  # Will normally re-create derivatives (per existing definitions) even if they already exist,
-  # but pass `lazy: false` to skip creating if a derivative with a given key already exists.
-  # This will use the asset `derivatives` association, so if you are doing this in bulk for several
-  # assets, you should eager-load the derivatives association for efficiency.
-  #
-  # ## Avoiding eager-download
-  #
-  # Additionally, this has a feature to 'trick' shrine into not eager downloading
-  # the original before our kithe_derivatives processor has a chance to decide if it
-  # needs to create any derivatives (based on `lazy` arg), making no-op
-  # create_derivatives so much faster and more efficient, which matters when doing
-  # bulk operations say with our rake task.
-  #
-  # kithe_derivatives processor must then do a Shrine.with_file to make sure
-  # it's a local file, when needed.
-  #
-  # See https://github.com/shrinerb/shrine/issues/470
-  #
+  # See more in docs for kithe at
+  # Shrine::Plugins::KitheDerivativeDefinitions::AttacherMethods#kithe_create_derivatives
   def create_derivatives(only: nil, except: nil, lazy: false)
-    source = file
-    return false unless source
-
-    local_files = file_attacher.process_derivatives(:kithe_derivatives, only: only, except: except, lazy: lazy)
-
-    # include any other configured processors
-    file_attacher.kithe_include_derivatives_processors.each do |processor|
-      local_files.merge!(
-        file_attacher.process_derivatives(processor.to_sym, only: only, except: except, lazy: lazy)
-      )
-    end
-
-    file_attacher.add_persisted_derivatives(local_files)
+    file_attacher.kithe_create_derivatives(only: only, except: except, lazy: lazy)
   end
 
 

--- a/guides/derivatives.md
+++ b/guides/derivatives.md
@@ -191,19 +191,21 @@ class AssetUploader < Kithe::uploader
 
   # pure shrine derivatives processor
   Attacher.derivatives(:my_custom_processor, download: false) do |original, **options|
-    return {} unless process_any_kithe_derivative?([:huge_thumb, :tiny_thumb], **options)
+    if process_any_kithe_derivative?([:huge_thumb, :tiny_thumb], **options)
+      return_derivatives = {}
 
-    return_derivatives = {}
+      if process_kithe_derivative?(:huge_thumb, **options)
+        return_derivatives[:huge_thumb] = create_something_huge
+      end
 
-    if process_kithe_derivative?(:huge_thumb, **options)
-      return_derivatives[:huge_thumb] = create_something_huge
+      if process_kithe_derivative?(:tny_thumb, **options)
+        return_derivatives[:tiny_thumb] = create_something_tiny
+      end
+
+      return_derivatives
+    else
+      {}
     end
-
-    if process_kithe_derivative?(:tny_thumb, **options)
-      return_derivatives[:tiny_thumb] = create_something_tiny
-    end
-
-    return_derivatives
   end
 end
 ```

--- a/lib/shrine/plugins/kithe_derivative_definitions.rb
+++ b/lib/shrine/plugins/kithe_derivative_definitions.rb
@@ -101,6 +101,38 @@ class Shrine
           end.freeze
         end
       end
+
+      module AttacherMethods
+        # a helper method that you can use in your own shrine processors to
+        # handle only/except/lazy guarding logic.
+        #
+        # @return [Boolean] should the `key` be processed based on only/except/lazy conditions?
+        #
+        # @param key [Symbol] derivative key to check for guarded processing
+        # @param only [Array<Symbol>] If present, method will only return true if `key` is included in `only`
+        # @param except [Array<Symbol] If present, method will only return true if `key` is NOT included in `except`
+        # @param lazy [Boolean] If true, method will only return true if derivative key is not already present
+        #   in attacher with a value.
+        #
+        def process_kithe_derivative?(key, **options)
+          key = key.to_sym
+          only = options[:only] && Array(options[:only]).map(&:to_sym)
+          except = options[:except] && Array(options[:except]).map(&:to_sym)
+          lazy = !! options[:lazy]
+
+          (only.nil? ? true : only.include?(key)) &&
+          (except.nil? || ! except.include?(key)) &&
+          (!lazy || !derivatives.keys.include?(key))
+        end
+
+        # Convenience to check #process_kithe_derivative? for multiple keys at once,
+        # @return true if any key returns true
+        #
+        # @example process_any_kithe_derivative?([:thumb_mini, :thumb_large], only: [:thumb_large, :thumb_mega], lazy: true)
+        def process_any_kithe_derivative?(keys, **options)
+          keys.any? { |k| process_kithe_derivative?(k, **options) }
+        end
+      end
     end
     register_plugin(:kithe_derivative_definitions, KitheDerivativeDefinitions)
   end

--- a/spec/shrine/kithe_derivative_definitions_spec.rb
+++ b/spec/shrine/kithe_derivative_definitions_spec.rb
@@ -313,4 +313,38 @@ describe "Shrine::Plugins::KitheDerivativeDefinitions", queue_adapter: :test do
       expect(CustomUploader::Attacher.defined_derivative_keys).to eq([])
     end
   end
+
+  describe "#process_kithe_derivative?" do
+    it "returns true for anything if no conditions" do
+      expect(asset.file_attacher.process_kithe_derivative?(:anything)).to be true
+    end
+
+    it "returns false if not in a present :only" do
+      expect(asset.file_attacher.process_kithe_derivative?(:something, only: [:else])).to be false
+    end
+
+    it "returns false if in a present :except" do
+      expect(asset.file_attacher.process_kithe_derivative?(:something, except: :something)).to be false
+    end
+
+    describe "lazy" do
+      let(:key) { "some_key" }
+      before do
+        asset.file_attacher.add_persisted_derivatives({key => StringIO.new("existing #{key} asset")})
+      end
+
+      it "returns false if lazy and present" do
+        expect(asset.file_attacher.process_kithe_derivative?(key, lazy: true)).to be false
+      end
+    end
+
+    describe "process_any_kithe_derivative?" do
+      it "returns true if any are true" do
+        expect(asset.file_attacher.process_any_kithe_derivative?([:only1, :only2], only: [:only1, :only2], except: [:only2])).to be true
+      end
+      it "returns false if none are true" do
+        expect(asset.file_attacher.process_any_kithe_derivative?([:only1, :only2], only: [:only2], except: [:only2])).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
I don't love how complex/abstract this is getting, but this was the best way I could find to support implementing our video thumbnail extraction. 

@eddierubeiz I don't know if you want to review this, or if it's going to be too overwhelming?  It might (or might not) be easier once you can see the scihist_digicoll PR that will use this functionality. Let me know what role you want to play in review and if you have any questions! 

- Use Attacher.kithe_include_derivatives_processors to opt additional shrine derivative processors into kithe derivative handling
- Attacher #process_kithe_derivative? and #process_any_kithe_derivative? -- give you an easy way to implement shrine only/except/lazy options when implementing your own shrine derivative processor. 
- refresh derivatives guide, including for new bring-your-own shrine derivative processor
- a refactor: move kithe create derivatives logic into Attacher via plugin