### PR TITLE
update github actions to checkout@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     name: test ${{ matrix.gemfile }}, ruby ${{ matrix.ruby }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1


### PR DESCRIPTION
It doens't make a difference at the moment except for being a more recent version of node, but let's stay current
