### PR TITLE
Changes to FffmpegExtractJpg

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,12 @@
 ## NEXT
 
+### Backwards incompatible change
+
+* FfmpegExtractJpg defaults to frame_sample_size: false, no frame sampling. It was too RAM risky. https://github.com/sciencehistory/kithe/pull/150
+
 ### Fixed
 
-*
+* Fix bug in FfmpegExtractJpg where you couldn't turn off frame sampling. https://github.com/sciencehistory/kithe/pull/150
 
 *
 

--- a/app/derivative_transformers/kithe/ffmpeg_extract_jpg.rb
+++ b/app/derivative_transformers/kithe/ffmpeg_extract_jpg.rb
@@ -15,18 +15,21 @@ module Kithe
     # @param start_seconds [Integer] seek to this point to find thumbnail. If it's
     #   after the end of the video, you won't get a thumb back though! [Default 0]
     #
-    # @param frame_sample_size [Integer] argument passed to ffmpeg thumbnail filter,
+    # @param frame_sample_size [Integer,false,nil] argument passed to ffmpeg thumbnail filter,
     #   how many frames to sample, starting at start_seconds, to choose representative
     #   thumbnail. If set to false, thumbnail filter won't be used. If this one
     #   goes past the end of the video, ffmpeg is fine with it. Set to `false` to
     #   disable use of ffmpeg sample feature, and just use exact frame at start_seconds.
-    #   [Default 900, around 30 seconds at 30 fps]
+    #
+    #   NOTE: This can consume significant RAM depending on value and video resolution.
+    #
+    #   [Default false, not operative]
     #
     # @width_pixels [Integer] output thumb at this width. aspect ratio will be
     #   maintained. Warning, if it's larger than video original, ffmpeg will
     #   upscale!  If set to nil, thumb will be output at original video
     #   resolution. [Default nil]
-    def initialize(start_seconds: 0, frame_sample_size: 900, width_pixels: nil)
+    def initialize(start_seconds: 0, frame_sample_size: false, width_pixels: nil)
       @start_seconds = start_seconds
       @frame_sample_size = frame_sample_size
       @width_pixels = width_pixels

--- a/app/derivative_transformers/kithe/ffmpeg_extract_jpg.rb
+++ b/app/derivative_transformers/kithe/ffmpeg_extract_jpg.rb
@@ -88,9 +88,10 @@ module Kithe
       ffmpeg_args.concat ["-i", input_arg]
 
       video_filter_parts = []
-      video_filter_parts << "thumbnail=#{frame_sample_size}" if frame_sample_size
+      video_filter_parts << "thumbnail=#{frame_sample_size}" if (frame_sample_size || 0) > 1
       video_filter_parts << "scale=#{width_pixels}:-1" if width_pixels
-      if video_filter_parts
+
+      if video_filter_parts.present?
         ffmpeg_args.concat ["-vf", video_filter_parts.join(',')]
       end
 

--- a/spec/derivative_transformers/ffmpeg_extract_jpg_spec.rb
+++ b/spec/derivative_transformers/ffmpeg_extract_jpg_spec.rb
@@ -12,8 +12,8 @@ describe Kithe::FfmpegExtractJpg do
       expect(Marcel::MimeType.for(StringIO.new(result.read))).to eq "image/jpeg"
     end
 
-    it "can extract without frame sample" do
-      extractor = Kithe::FfmpegExtractJpg.new(frame_sample_size: false)
+    it "can extract with a frame sample" do
+      extractor = Kithe::FfmpegExtractJpg.new(frame_sample_size: 300)
 
       result = extractor.call(video_path)
 

--- a/spec/derivative_transformers/ffmpeg_extract_jpg_spec.rb
+++ b/spec/derivative_transformers/ffmpeg_extract_jpg_spec.rb
@@ -11,6 +11,15 @@ describe Kithe::FfmpegExtractJpg do
       expect(result).to be_kind_of(Tempfile)
       expect(Marcel::MimeType.for(StringIO.new(result.read))).to eq "image/jpeg"
     end
+
+    it "can extract without frame sample" do
+      extractor = Kithe::FfmpegExtractJpg.new(frame_sample_size: false)
+
+      result = extractor.call(video_path)
+
+      expect(result).to be_kind_of(Tempfile)
+      expect(Marcel::MimeType.for(StringIO.new(result.read))).to eq "image/jpeg"
+    end
   end
 
   describe "from File" do


### PR DESCRIPTION
1. Fix bug where you couldn't disable frame sampling
2. default to no frame sample (backwards incompat, yeah) As discovered in our local app, frame sampling can use a huge amount of RAM for high-res video, better not to default to it. 
