### PR TITLE
Allow Kithe.indexable_settings.writer_settings to be mutated as per docs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 
 * Fix bug in FfmpegExtractJpg where you couldn't turn off frame sampling. https://github.com/sciencehistory/kithe/pull/150
 
-*
+* Allow Kithe.indexable_settings.writer_settings to be mutated as per docs https://github.com/sciencehistory/kithe/pull/151
 
 ### Added
 

--- a/lib/kithe/indexable_settings.rb
+++ b/lib/kithe/indexable_settings.rb
@@ -6,22 +6,21 @@ module Kithe
     def initialize(solr_url:, writer_class_name:, writer_settings:,
                    model_name_solr_field:, solr_id_value_attribute:, disable_callbacks: false,
                    batching_mode_batch_size: 100)
-      @solr_url = solr_url
       @writer_class_name = writer_class_name
       @writer_settings = writer_settings
       @model_name_solr_field = model_name_solr_field
       @solr_id_value_attribute = solr_id_value_attribute || 'id'
       @batching_mode_batch_size = batching_mode_batch_size
+
+      # use our local setter to set solr_url also in writer_settings
+      solr_url = solr_url
     end
 
-    # Use configured solr_url, and merge together with configured
-    # writer_settings
-    def writer_settings
-      if solr_url
-        { "solr.url" => solr_url }.merge(@writer_settings)
-      else
-        @writer_settings
-      end
+
+    # set solr_url also in writer_settings, cause it's expected there.
+    def solr_url=(v)
+      @solr_url = v
+      writer_settings["solr.url"] = v if writer_settings
     end
 
     # Turn writer_class_name into an actual Class object.

--- a/spec/models/kithe_spec.rb
+++ b/spec/models/kithe_spec.rb
@@ -6,5 +6,19 @@ describe "Kithe module" do
       expect(Rails.logger).not_to be_nil
       expect(Kithe.indexable_settings.writer_settings["logger"]).to be(Rails.logger)
     end
+
+    describe "#writer_settings" do
+      it "allows mutation by key" do
+        Kithe.indexable_settings.writer_settings["solr_writer.http_timeout"] = 10
+        expect(Kithe.indexable_settings.writer_settings["solr_writer.http_timeout"]).to eq(10)
+      end
+
+      it "allows mutation by merge!" do
+        Kithe.indexable_settings.writer_settings.merge!(
+          "solr_writer.solr_update_args" => {}
+        )
+        expect(Kithe.indexable_settings.writer_settings["solr_writer.solr_update_args"]).to eq({})
+      end
+    end
   end
 end


### PR DESCRIPTION
The way we were creating a new hash dynamically on each method call means mutating the return value was not preserved. This broke existing examples in kithe docs like `Kithe.indexable_settings.writer_settings.merge!`.

We fix that, while still preserving the fact that changing #solr_url has an effect on #writer_settings, by simply giving it that side effect.
