### PR TITLE
Revert "Order Work#members by position by default"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,10 @@
 
 *
 
+## 2.6.1 (Aug 23 2022)
+
+Reverts "Work#members association is ordered by default" from 2.6.0, turns out backwards incompat. https://github.com/sciencehistory/kithe/pull/153
+
 
 ## 2.6.0 (Aug 11 2022)
 
@@ -27,7 +31,7 @@
 
 ### Added
 
-* Work#members association is ordered by default, by position column, then created_at. https://github.com/sciencehistory/kithe/pull/146
+* Work#members association is ordered by default, by position column, then created_at. https://github.com/sciencehistory/kithe/pull/146 [REVERTED in 2.6.1]
 
 * Allow remove_derivatives to receive string arg normalized to symbol https://github.com/sciencehistory/kithe/pull/147
 

--- a/app/models/kithe/model.rb
+++ b/app/models/kithe/model.rb
@@ -32,9 +32,8 @@ class Kithe::Model < ActiveRecord::Base
   # this should only apply to Works, but we define it here so we can preload it
   # when fetching all Kithe::Model. And it's to Kithe::Model so it can include
   # both Works and Assets. We do some app-level validation to try and make it used
-  # as intended. Members are by default ordered by position, then created_at.
-  has_many :members, -> { order(position: :asc, created_at: :asc) },
-    class_name: "Kithe::Model", foreign_key: :parent_id,
+  # as intended.
+  has_many :members, class_name: "Kithe::Model", foreign_key: :parent_id,
     inverse_of: :parent, dependent: :destroy
 
   belongs_to :parent, class_name: "Kithe::Model", inverse_of: :members, optional: true

--- a/spec/models/kithe/work_spec.rb
+++ b/spec/models/kithe/work_spec.rb
@@ -37,15 +37,6 @@ RSpec.describe Kithe::Work, type: :model do
     }.to raise_error(ActiveRecord::RecordInvalid)
   end
 
-  it "sorts members properly" do
-    work.members << FactoryBot.create(:kithe_asset, title: "three", position: nil, created_at: 2.days.ago)
-    work.members << FactoryBot.create(:kithe_asset, title: "two", position: 2)
-    work.members << FactoryBot.create(:kithe_asset, title: "four", position: nil, created_at: 1.day.ago)
-    work.members << FactoryBot.create(:kithe_asset, title: "one", position: 1)
-
-    expect(work.members.map(&:title)).to eq(["one", "two", "three", "four"])
-  end
-
   it "can create new with collection id" do
     work = FactoryBot.build(:kithe_work, contained_by_ids: [collection.id])
     work.save!


### PR DESCRIPTION
Caused backwards incompat in some case -- I think default sort in AR association is weird and fragile actually. If you try to do a `pluck` in some cases that don't include the defualt order by client, then postgres complains, eg:

```
      Failure/Error:
        self.members.
          includes(:leaf_representative).
          references(:leaf_representative).
          pluck(Arel.sql("
            DISTINCT leaf_representatives_kithe_models.file_data -> 'metadata' -> 'mime_type', kithe_models.file_data -> 'metadata' -> 'mime_type'"
          )).flatten.compact.uniq

      ActiveRecord::StatementInvalid:
        PG::InvalidColumnReference: ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list
        LINE 2: ...d" WHERE "kithe_models"."parent_id" = $1 ORDER BY "kithe_mod...
```
