### PR TITLE
Fix for Rails 7 breaking recommended single-table-inheritance approach

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,6 @@
 ### Fixed
 
 *
-
 *
 
 ### Added
@@ -11,6 +10,13 @@
 *
 
 *
+
+## 2.7.0
+
+### Fixed
+
+* A fix for Rails 7 and Kithe::Model Single-Table Inheritance in development-mode. https://github.com/sciencehistory/kithe/pull/154
+
 
 ## 2.6.1 (Aug 23 2022)
 

--- a/lib/kithe/engine.rb
+++ b/lib/kithe/engine.rb
@@ -15,6 +15,23 @@ require "kithe/config_base"
 
 module Kithe
   class Engine < ::Rails::Engine
+
+    # Rails Single-table-inheritance auto-load workaround, further worked around
+    # for Rails 7.
+    #
+    # https://github.com/rails/rails/issues/46625
+    # https://github.com/rails/rails/issues/45307
+    #
+    # Descendants wont' be pre-loaded during initialization, but this is the best
+    # we can do.
+    initializer ("kithe.preload_single_table_inheritance") do
+      unless Rails.configuration.cache_classes && Rails.configuration.eager_load
+        Rails.configuration.to_prepare do
+          Kithe::Model.preload_sti unless Kithe::Model.preloaded
+        end
+      end
+    end
+
     config.generators do |g|
       g.test_framework :rspec, :fixture => false
       g.fixture_replacement :factory_bot, :dir => 'spec/factories'

--- a/lib/kithe/engine.rb
+++ b/lib/kithe/engine.rb
@@ -25,9 +25,11 @@ module Kithe
     # Descendants wont' be pre-loaded during initialization, but this is the best
     # we can do.
     initializer ("kithe.preload_single_table_inheritance") do
-      unless Rails.configuration.cache_classes && Rails.configuration.eager_load
+      unless false && Rails.configuration.cache_classes && Rails.configuration.eager_load
         Rails.configuration.to_prepare do
           Kithe::Model.preload_sti unless Kithe::Model.preloaded
+        rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid => e
+          Rails.logger.debug("Could not pre-load Kithe::Models Single-Table Inheritance descendents: #{e.inspect}")
         end
       end
     end

--- a/lib/kithe/sti_preload.rb
+++ b/lib/kithe/sti_preload.rb
@@ -8,8 +8,13 @@ module Kithe
   # on particular inheritance hieararchies.
   #
   # We include in our Kithe::Model, which uses Single-Table Inheritance
+  #
+  # BUT NOTE:  What's in Rails Guide right now actually breaks in Rails 7.
+  #
+  # We've messed with based on https://github.com/rails/rails/issues/45307 et al.
+  #
   module StiPreload
-    unless Rails.application.config.eager_load
+    unless Rails.configuration.cache_classes && Rails.configuration.eager_load
       extend ActiveSupport::Concern
 
       included do
@@ -17,10 +22,13 @@ module Kithe
       end
 
       class_methods do
-        def descendants
-          preload_sti unless preloaded
-          super
-        end
+
+        # For Rails 7, this now breaks; we work around with an after_initialize hook
+        # in ./kithe/engine.rb . See more links there.
+        # def descendants
+        #   preload_sti unless preloaded
+        #   super
+        # end
 
         # Constantizes all types present in the database. There might be more on
         # disk, but that does not matter in practice as far as the STI API is


### PR DESCRIPTION
We were using an approach to Single-Table Inheritance recommended by Rails guide at: https://guides.rubyonrails.org/v7.0/autoloading_and_reloading_constants.html#single-table-inheritance

But this breaks in Rails 7.  There's an Issue in Rails github where contributors are discussing it: https://github.com/rails/rails/issues/45307

It looks like this is considered a bug in the guide-recommended STI approach, rather than a bug in Rails. They haven't yet consensed on an exact solution, but solution here is my best effort taken from what they are arriving at in discussion there.

It does require the STI base class to be explicitly mentioned in an initializer, when before everything was totally automatic. But this engine only has one, Kithe::Model, so this engine can take care of the one this engine is providing, no problem.
