### PR TITLE
Updated appraisal gemfiles

### DIFF
--- a/gemfiles/rails_52.gemfile
+++ b/gemfiles/rails_52.gemfile
@@ -8,6 +8,7 @@ group :development, :test do
   gem "rspec-rails", "~> 4.0"
   gem "pry-byebug", "~> 3.6"
   gem "factory_bot_rails", "~> 4.11"
+  gem "sprockets-rails"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_60.gemfile
+++ b/gemfiles/rails_60.gemfile
@@ -8,6 +8,7 @@ group :development, :test do
   gem "rspec-rails", "~> 4.0"
   gem "pry-byebug", "~> 3.6"
   gem "factory_bot_rails", "~> 4.11"
+  gem "sprockets-rails"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_61.gemfile
+++ b/gemfiles/rails_61.gemfile
@@ -8,6 +8,7 @@ group :development, :test do
   gem "rspec-rails", "~> 4.0"
   gem "pry-byebug", "~> 3.6"
   gem "factory_bot_rails", "~> 4.11"
+  gem "sprockets-rails"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_70.gemfile
+++ b/gemfiles/rails_70.gemfile
@@ -9,6 +9,7 @@ group :development, :test do
   gem "rspec-rails", "~> 4.0"
   gem "pry-byebug", "~> 3.6"
   gem "factory_bot_rails", "~> 4.11"
+  gem "sprockets-rails"
 end
 
 gemspec path: "../"


### PR DESCRIPTION
From just running `bundle exec appraisal install`, I guess they had gotten out of sync, we had forgotten to do that before. Don't recall what' going on with sprockets-rails that we changed, but will assume it's correct.
