### PR TITLE
Rails STI: Eliminate accidental `false` short-circuit left in preload check for testing only

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,12 @@
 
 *
 
+## 2.7.1
+
+### Fixed
+
+* Severe bug in Single-Table Inheritance fix in 2.7.0 fixed, https://github.com/sciencehistory/kithe/pull/156
+
 ## 2.7.0
 
 ### Fixed

--- a/lib/kithe/engine.rb
+++ b/lib/kithe/engine.rb
@@ -25,9 +25,9 @@ module Kithe
     # Descendants wont' be pre-loaded during initialization, but this is the best
     # we can do.
     initializer ("kithe.preload_single_table_inheritance") do
-      unless false && Rails.configuration.cache_classes && Rails.configuration.eager_load
+      unless Rails.configuration.cache_classes && Rails.configuration.eager_load
         Rails.configuration.to_prepare do
-          Kithe::Model.preload_sti unless Kithe::Model.preloaded
+          Kithe::Model.preload_sti if Kithe::Model.respond_to?(:preloaded) && !Kithe::Model.preloaded
         rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid => e
           Rails.logger.debug("Could not pre-load Kithe::Models Single-Table Inheritance descendents: #{e.inspect}")
         end

--- a/lib/kithe/version.rb
+++ b/lib/kithe/version.rb
@@ -1,3 +1,3 @@
 module Kithe
-  VERSION = '2.7.0'
+  VERSION = '2.7.1'
 end


### PR DESCRIPTION
Also an additional check for method existence before calling it, just for extra safeguard.

with bump version to 2.7.1