### PR TITLE
CI on ruby 3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gemspec
 
 group :development, :test do
   gem 'rspec-rails', '~> 6.0'
+  gem 'rspec-mocks', '>= 3.12.1' # for ruby 3.2 need at least
   gem 'pry-byebug', '~> 3.6'
   gem 'factory_bot_rails', '~> 6.2'
   # only used for current mechanism of testing working with cocoon JS

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ So you want to start an app that uses kithe. We should later provide better 'get
 
 * Again re-iterate that kithe requires your Rails app use postgres, 9.5+.
 
-* kithe works with Rails 5.2 through 6.1.
+* kithe works with Rails 5.2 through 7.0.
 
 * To install migrations from kithe to setup your database for it's models: `rake kithe_engine:install:migrations`
 


### PR DESCRIPTION
No code changes needed to pass CI on ruby 3.2, no new release should be required. 

(We did require the latest rspec-mocks for our test suite itself to work on ruby 3.2)