### PR TITLE
get ready for attr_json 2.x, where AttrJson::Record::Dirty won't exist.

### DIFF
--- a/app/models/kithe/model.rb
+++ b/app/models/kithe/model.rb
@@ -7,7 +7,7 @@ class Kithe::Model < ActiveRecord::Base
 
   include AttrJson::Record
   include AttrJson::NestedAttributes
-  include AttrJson::Record::Dirty
+  include AttrJson::Record::Dirty if defined?(AttrJson::Record::Dirty)
   include Kithe::Indexable
 
   # While Rails STI means the actual specific class is in `type`, sometimes


### PR DESCRIPTION
Kithe gemspec already allows pre-release of attr_json 2 as opt-in (although not final version). This can allow some testing
