### PR TITLE
Allow attr_json 2.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,13 @@
 
 *
 
+## 2.8.0
+
+## Added
+
+* Allow attr_json 2.0, while still allowing 1.0.  If you want one or the other specifically, you may want to lock in your own gemfile. https://github.com/jrochkind/attr_json/blob/master/CHANGELOG.md#200
+
+
 ## 2.7.1
 
 ### Fixed

--- a/kithe.gemspec
+++ b/kithe.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.5'
 
   s.add_dependency "rails", ">= 5.2.1", "< 7.1"
-  s.add_dependency "attr_json", "< 2.0.0"
+  s.add_dependency "attr_json", "< 3.0.0"
 
   s.add_dependency "simple_form", ">= 4.0", "< 6.0"
   s.add_dependency "shrine", "~> 3.3" # file attachment handling

--- a/lib/kithe/version.rb
+++ b/lib/kithe/version.rb
@@ -1,3 +1,3 @@
 module Kithe
-  VERSION = '2.7.1'
+  VERSION = '2.8.0'
 end


### PR DESCRIPTION
we're still allowing 1.x too.  We're not going to update major version of kithe.

This is a bit fast and loose, as one could imagine a downstream app for which updating to attr_json 2 might break it. But kithe isn't super popular, we think we may know all current users, who are fine with it.
