### PR TITLE
rake kithe:create_derivatives gets some options for creating Background Activejob

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,8 @@
 
 ### Added
 
-*
+*  `Kithe::CreateDerivativesJob` can take arguments for #create_derivatives, and rake task
+   `kithe:create_derivatives` can now be used to enqueue bg jobs, one per asset. https://github.com/sciencehistory/kithe/pull/166
 
 *
 

--- a/app/jobs/kithe/create_derivatives_job.rb
+++ b/app/jobs/kithe/create_derivatives_job.rb
@@ -1,6 +1,22 @@
 module Kithe
+  # Create derivatives in a bg job.
+  #
+  # Used as part of kithe standard ingest flow, to create all derivatives in bg job for new
+  # ingest
+  #
+  # Can also be used explicitly, with args, to create only certain derivs, optionally lazily
+  #
+  # @example
+  #
+  #   CreateDerivativesJob.new(asset).perform_later
+  #
+  #   CreateDerivativesJob.new(asset, lazy: true).perform_later
+  #
+  #   CreateDerivativesJob.new(asset, only: :some_deriv, lazy: true).perform_later
+  #
+  #   CreateDerivativesJob.new(asset, except: :other_deriv, lazy: true).perform_later
   class CreateDerivativesJob < Job
-    def perform(asset)
+    def perform(asset, lazy: false, only: nil, except: nil)
         asset.create_derivatives
     end
     # This error typically occurs when several large assets, whose derivatives

--- a/app/jobs/kithe/create_derivatives_job.rb
+++ b/app/jobs/kithe/create_derivatives_job.rb
@@ -17,7 +17,7 @@ module Kithe
   #   CreateDerivativesJob.new(asset, except: :other_deriv, lazy: true).perform_later
   class CreateDerivativesJob < Job
     def perform(asset, lazy: false, only: nil, except: nil)
-        asset.create_derivatives
+        asset.create_derivatives(lazy: lazy, only: only, except: except)
     end
     # This error typically occurs when several large assets, whose derivatives
     # take a long time to generate, are deleted immediately after ingest.

--- a/guides/derivatives.md
+++ b/guides/derivatives.md
@@ -234,7 +234,21 @@ Kithe gives you some rake tasks for creating derivatives in bulk. The tasks will
 
 `./bin/rake kithe:create_derivatives:lazy_defaults` will go through all assets, and create derivatives for all derivative definitions you have configured, only for those derivative keys that don't yet exist. This is useful if you've added a new derivative definition, or otherwise want to ensure all derivatives are created.
 
-`./bin/rake kithe:create_derivatives` has more flexibility specify derivative definitions to create and other parameters, including forcefully re-creating (if your definitions have changed). More example docs could be useful, but for now try running `./bin/rake kithe:create_derivatives -- -h`
+`./bin/rake kithe:create_derivatives` has more flexibility specify derivative definitions to create and other parameters, including forcefully re-creating (if your definitions have changed). It also has the ability to create background jobs (ActiveJob) per asset for actual creation work.
+
+Run `./bin/rake kithe:create_derivatives -- -h` for some argument info. (Note the `--` separator argument).
+
+    # IDs are friendlier_id
+    ./bin/rake kithe:create_derivatives --work-id=tnroyhj,x7kpj2z
+
+    # Specify specific derivatives, and/or lazy creation (only if not already present)
+    ./bin/rake kithe:create_derivatives --lazy --derivative=my_derivative_name,other
+
+    # Specify create per-asset bg jobs for creation
+    ./bin/rake kithe:create_derivatives --lazy --bg
+
+    # Or specify specific ActiveJob queue too
+    ./bin/rake kithe:create_derivatives --lazy --derivative=some_name --bg=queue_name
 
 ## Manually modifying derivatives
 

--- a/spec/jobs/create_derivatives_job_spec.rb
+++ b/spec/jobs/create_derivatives_job_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe Kithe::CreateDerivativesJob, type: :job do
+  let(:asset) { FactoryBot.create(:kithe_asset) }
+
+  describe "with only asset arg" do
+    it "calls #create_derivatives with args" do
+      expect(asset).to receive(:create_derivatives).with(lazy: false, only: nil, except: nil)
+
+      Kithe::CreateDerivativesJob.perform_now(asset)
+    end
+  end
+
+  describe "with other args" do
+    it "calls #create_derivatives with other args" do
+      expect(asset).to receive(:create_derivatives).with(
+        lazy: true, only: :only_deriv, except: [:except_deriv1, :except_deriv2]
+      )
+
+      Kithe::CreateDerivativesJob.perform_now(asset, lazy: true, only: :only_deriv, except: [:except_deriv1, :except_deriv2])
+    end
+  end
+end


### PR DESCRIPTION
We already had a `kithe:create_derivatives` task with many options for different things you'd want to do for creating derivatives -- but it did it all in the foreground, serially, in a single thread. 

I had need to instead create many small background jobs (which we can then easily handle on heroku by scaling up workers, to get it done quickly!). And realized small changes to the existing CreateDerivativesJob and the rake task would make that possible. 

So do so here. 

For the thing we want to do in our app, for instance, we can run (on heroku even)

> heroku run "rake kithe:create_derivatives -- --derivatives=graphiconly_pdf --lazy --bg=special_jobs"

That will create one BG job per Asset (for all assets!), in the ActiveJob queue `special_jobs`.  The job will be queued up for every Asset, but since we said "lazy", it will only actually create the `graphiconly_pdf` derivative if one doesn't already exist, otherwise the job will just exit. 