### PR TITLE
Kithe::Model sub-classes should filter_attributes :json_attributes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-*
+*  Kithe::Model sub-classes filter_attributes :json_attributes https://github.com/sciencehistory/kithe/pull/169
 
 *
 

--- a/app/models/kithe/model.rb
+++ b/app/models/kithe/model.rb
@@ -27,6 +27,11 @@ class Kithe::Model < ActiveRecord::Base
 
   attr_json_config(default_accepts_nested_attributes: { reject_if: :all_blank })
 
+  # keep json_attributes column out of #inspect display of model shown in logs and
+  # console -- because it can be huge, and is generally duplicated by individual
+  # attributes already included.
+  self.filter_attributes = [:json_attributes]
+
   validates_presence_of :title
 
   # this should only apply to Works, but we define it here so we can preload it

--- a/app/models/kithe/model.rb
+++ b/app/models/kithe/model.rb
@@ -29,8 +29,10 @@ class Kithe::Model < ActiveRecord::Base
 
   # keep json_attributes column out of #inspect display of model shown in logs and
   # console -- because it can be huge, and is generally duplicated by individual
-  # attributes already included.
-  self.filter_attributes = [:json_attributes]
+  # attributes already included. filter_attributes only supported in Rails 6+
+  if self.respond_to?(:filter_attributes)
+    self.filter_attributes += [:json_attributes]
+  end
 
   validates_presence_of :title
 


### PR DESCRIPTION
Keep the json_attributes column out of of #inspect display of model shown in logs and console -- because it can be huge, and is generally duplicated by individual attributes that will be included anyway.
