### PR TITLE
Actually test on all Rails versions we intended to with appraisal!

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,13 +1,13 @@
 appraise "rails-60" do
-  gem "rails", "~> 6.0"
+  gem "rails", "~> 6.0.0"
 end
 
 appraise "rails-61" do
-  gem "rails", "~> 6.1"
+  gem "rails", "~> 6.1.0"
 end
 
 appraise "rails-70" do
-  gem "rails", "~> 7.0"
+  gem "rails", "~> 7.0.0"
 
   # sprockets-rails is generated into gemfile in Rails 7.0, where it
   # was a gemspec dependency in previous rails. We'll just
@@ -17,7 +17,7 @@ appraise "rails-70" do
 end
 
 appraise "rails-71" do
-  gem "rails", "~> 7.1"
+  gem "rails", "~> 7.1.0"
 
   # sprockets-rails is generated into gemfile in Rails 7.1, where it
   # was a gemspec dependency in previous rails. We'll just

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gemspec
 # gem 'byebug', group: [:development, :test]
 
 group :development, :test do
-  gem 'rspec-rails', '~> 6.0'
+  gem 'rspec-rails', '>= 5.0', '< 7'
   gem 'rspec-mocks', '>= 3.12.1' # for ruby 3.2 need at least
   gem 'pry-byebug', '~> 3.6'
   # 6.3.0 and 6.4.0 have a bug https://github.com/thoughtbot/factory_bot_rails/issues/433

--- a/gemfiles/rails_60.gemfile
+++ b/gemfiles/rails_60.gemfile
@@ -2,10 +2,10 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 6.0"
+gem "rails", "~> 6.0.0"
 
 group :development, :test do
-  gem "rspec-rails", "~> 6.0"
+  gem "rspec-rails", ">= 5.0", "< 7"
   gem "rspec-mocks", ">= 3.12.1"
   gem "pry-byebug", "~> 3.6"
   gem "factory_bot_rails", "~> 6.2", "!= 6.3.0", "!= 6.4.0"

--- a/gemfiles/rails_61.gemfile
+++ b/gemfiles/rails_61.gemfile
@@ -2,10 +2,10 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 6.1"
+gem "rails", "~> 6.1.0"
 
 group :development, :test do
-  gem "rspec-rails", "~> 6.0"
+  gem "rspec-rails", ">= 5.0", "< 7"
   gem "rspec-mocks", ">= 3.12.1"
   gem "pry-byebug", "~> 3.6"
   gem "factory_bot_rails", "~> 6.2", "!= 6.3.0", "!= 6.4.0"

--- a/gemfiles/rails_70.gemfile
+++ b/gemfiles/rails_70.gemfile
@@ -2,11 +2,11 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 7.0"
+gem "rails", "~> 7.0.0"
 gem "sprockets-rails", require: "sprockets/railtie"
 
 group :development, :test do
-  gem "rspec-rails", "~> 6.0"
+  gem "rspec-rails", ">= 5.0", "< 7"
   gem "rspec-mocks", ">= 3.12.1"
   gem "pry-byebug", "~> 3.6"
   gem "factory_bot_rails", "~> 6.2", "!= 6.3.0", "!= 6.4.0"

--- a/gemfiles/rails_71.gemfile
+++ b/gemfiles/rails_71.gemfile
@@ -2,12 +2,12 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 7.1"
+gem "rails", "~> 7.1.0"
 gem "sprockets-rails", require: "sprockets/railtie"
 gem "db-query-matchers", branch: "allow_rails_7.1", git: "https://github.com/jrochkind/db-query-matchers.git"
 
 group :development, :test do
-  gem "rspec-rails", "~> 6.0"
+  gem "rspec-rails", ">= 5.0", "< 7"
   gem "rspec-mocks", ">= 3.12.1"
   gem "pry-byebug", "~> 3.6"
   gem "factory_bot_rails", "~> 6.2", "!= 6.3.0", "!= 6.4.0"


### PR DESCRIPTION
Turns out eg  `"~> 7.0"` and `"~> 7.1"` _both_ mean latest 7.x!  So we weren't actually testing on 7.0.

Fix to actually test on 6.0.x, 6.1.x, 7.0.x, and 7.1.x.
