### PR TITLE
kithe_earlier_after_commit gives you a way to register after_commit to fire EARLIER than all previously registered

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 * New method Kithe::Model.kithe_earlier_after_commit can be used to register an after_commit
   hook that will fire BEFORE any existing after_commit hooks -- including shrine promotion-related
-  ones -- and will work consistently in any version of Rails including Rails 7.1 with run_after_transaction_callbacks_in_order_defined
+  ones -- and will work consistently in any version of Rails including Rails 7.1 with run_after_transaction_callbacks_in_order_defined. https://github.com/sciencehistory/kithe/pull/178
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,9 @@
 
 *  Kithe::Model sub-classes filter_attributes :json_attributes https://github.com/sciencehistory/kithe/pull/169
 
-*
+* New method Kithe::Model.kithe_earlier_after_commit can be used to register an after_commit
+  hook that will fire BEFORE any existing after_commit hooks -- including shrine promotion-related
+  ones -- and will work consistently in any version of Rails including Rails 7.1 with run_after_transaction_callbacks_in_order_defined
 
 ### Fixed
 

--- a/guides/file_handling.md
+++ b/guides/file_handling.md
@@ -175,6 +175,25 @@ If you have a reference to a Kithe::Asset instance, you can see if it's been pro
 
 In any case, when you assign and save _new_ file information on an asset, any previous stored bytes and derivatives are automatically cleaned up for you, in a reliable and concurrency-safe fashion.
 
+### an after_commit that happens before shrine promotion?
+
+Shrine promotes `cache` file to `stored` in an ActiveRecord `after_commit` hook it registers on Asset.
+
+Sometimes you want your own after_commit hook that happens _before_ this, at a point when
+Rails dirty tracking `previous_changes` still records the change that _triggered_ the promotion,
+rather than the promotion itself. Depending on the version of Rails you are using and configuraition, this may happen anyway, or be very hard to make happen.
+
+We give you a method to ensure a after_commit hook that happens _before_ previously
+registered after_commits, that is _before_ the Shrine promotion after_commit.
+
+    class MyAsset < Kithe::Asset
+      kithe_earlier_after_commit :will_execute_before_promotion
+
+      kithe_earlier_after_commit do
+        # will execute before promotion
+      end
+    end
+
 <a name="readingFiles"></a>
 ### Reading files and file info
 

--- a/spec/models/kithe/asset/asset_earlier_after_commit_spec.rb
+++ b/spec/models/kithe/asset/asset_earlier_after_commit_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+describe "Kithe::Asset#kithe_earlier_after_commit" do
+  let(:sample_image_path) { Kithe::Engine.root + "spec/test_support/images/1x1_pixel.jpg" }
+
+  describe "ordering against shrine's activerecord after_commit" do
+    before do
+      $called_before_promotion = false
+    end
+
+    temporary_class("CustomAsset") do
+      Class.new(Kithe::Asset) do
+        kithe_earlier_after_commit :my_earlier_after_commit
+
+        def my_earlier_after_commit
+        end
+      end
+    end
+
+    let!(:asset) { CustomAsset.create!(title: "test") }
+
+    it "calls my_earlier_after_commit before promotion" do
+      asset.set_promotion_directives(promote: :inline)
+
+      called_pre_promotion = false
+
+      # our hook gets called lots of times, but as long as it was called at least
+      # once before promotion... that fails with just `after_commit`, `kithe_earlier_after_commit`
+      # is needed to make sure we're getting called first.
+      allow(asset).to receive(:my_earlier_after_commit) do
+        if !asset.file_attacher.stored?
+          called_pre_promotion = true
+        end
+      end
+
+      asset.file = File.open(Kithe::Engine.root + "spec/test_support/images/1x1_pixel.jpg")
+      asset.save!
+
+      expect(called_pre_promotion).to be true
+    end
+  end
+
+  describe "ordering of custom after_commits" do
+    temporary_class("ParentAsset") do
+      Class.new(Kithe::Asset) do
+        after_commit :parent_after_commit
+
+        def parent_after_commit
+        end
+      end
+    end
+
+    temporary_class("ChildAsset") do
+      Class.new(ParentAsset) do
+        kithe_earlier_after_commit :child_earlier_after_commit
+
+        def child_earlier_after_commit
+        end
+      end
+    end
+
+    let!(:child_asset) { ChildAsset.create(title: "child")}
+
+    it "calls earlier_after_commit first" do
+      expect(child_asset).to receive(:child_earlier_after_commit).ordered
+      expect(child_asset).to receive(:parent_after_commit).ordered
+
+      child_asset.title = "new title"
+      child_asset.save!
+    end
+  end
+end


### PR DESCRIPTION
And will work regardless of Rails version, including Rails 7.1 with run_after_transaction_callbacks_in_order_defined

The use case is that sometimes you (or in this case me) need an after_commit that will be triggered _before_ promotion, when
Rails dirty tracking `previous_changes` still shows the changes BEFORE promotion, the ones that triggered promotion.

In Rails 7.0, this happened naturally/automatically. But Rails 7.1 by default reverses the order of after_commits -- and no longer even lets us use `prepend` args to override this. See https://github.com/rails/rails/issues/50118

And: https://discourse.shrinerb.com/t/warning-rails-7-1-new-ordering-of-after-commit-can-effect-shrine/663

But in my local app I really needed an after_commit that runs before promotion, and has access to that dirty tracking. So I looked into the internal implementation, and figured out a way to register ActiveRecord callbacks still using the prepend option (that Rails `after_commit` makes no longer available), to accomplish what we needed.

The wacky things we are doing to let a sub-class override the shrine attachment class from a superclass make this more confusing -- but don't actually cause the problem. In any case where you have a superclass registering shrine ActiveRecord promotion callbacks, but need to register other `after_commit` to come _first_ -- you'd have the problem. Even without overriding attachment class. 

There could be other solutions, like not using shrine activerecord out of the box callbacks but supplying our own, with more complicated logic or as a method instead of inline block so have ability to use `skip_callback` on them... but this actually looked like simplest solution. 

It is weird and confusing -- we tried to supply robust tests. 