### PR TITLE
Switch to new ActiveRecord enum args, not deprecated in Rails 7.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,12 @@
 
 *
 
+## 2.15.1
+
+### Fixed
+
+* Use new ActiveRecord enum args in Raisl 7.0+ to avoid Rails 7.2 deprecation notice. https://github.com/sciencehistory/kithe/pull/182
+
 ## 2.15.0
 
 ### Added

--- a/app/models/kithe/model.rb
+++ b/app/models/kithe/model.rb
@@ -23,7 +23,13 @@ class Kithe::Model < ActiveRecord::Base
   #
   # Since the rails enum uses an int field, this doens't take up too much extra
   # space in pg or anything, and is convenient.
-  enum kithe_model_type: { collection: 0, work: 1, asset: 2}
+  #
+  # Start using new non-deprecated args in Rails 7.0
+  if Rails.gem_version < Gem::Version.new("7.0")
+    enum kithe_model_type: { collection: 0, work: 1, asset: 2}
+  else
+    enum :kithe_model_type, { collection: 0, work: 1, asset: 2}
+  end
 
   attr_json_config(default_accepts_nested_attributes: { reject_if: :all_blank })
 

--- a/lib/kithe/version.rb
+++ b/lib/kithe/version.rb
@@ -1,3 +1,3 @@
 module Kithe
-  VERSION = '2.15.0'
+  VERSION = '2.15.1'
 end


### PR DESCRIPTION
Rails 7.2 says:
```
DEPRECATION WARNING: Defining enums with keyword arguments is deprecated and will be removed
in Rails 8.0. Positional arguments should be used instead:

enum :kithe_model_type, {:collection=>0, :work=>1, :asset=>2}
```

Turns out new form is only available in Rails 7.0, and we're still supporting Rails 6.0 and 6.1 for some reason, so we'll put it in a condition on rails version. 
