### PR TITLE
Workaround bug where rails does not 'require' logger

### DIFF
--- a/lib/kithe.rb
+++ b/lib/kithe.rb
@@ -13,6 +13,14 @@ require 'kithe/indexable_settings'
 # we can stop require'ing it here, it's just a weird workaround.
 require 'yell'
 
+
+# bug in Rails pre-7.0 requires us to manually 'require' logger dep, Rails isn't going
+# to release a fix. https://github.com/rails/rails/pull/54264
+#
+# Tried to do this conditionally only if Rails < 7.1, but hard with order of
+# dependency loading. This is fine.
+require 'logger'
+
 module Kithe
   # for ruby-progressbar
   STANDARD_PROGRESS_BAR_FORMAT = "%a %t: |%B| %R/s %c/%u %p%% %e"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-#
+
 require 'byebug'
 require 'webmock/rspec'
 require 'db_query_matchers'


### PR DESCRIPTION
Logger got moved to default gems a while ago in ruby versions, and rails should have been 'require'ing it but wasn't. This was hidden by the fact that concurrent-ruby used to 'require' it, but no longer does. With recent versions of concurrent-ruby, somebody needs to 'require' logger -- Rails does not plan to release a fix for pre-7.1 rails.

So we can simply require it in our spec_helper for CI no big deal.
