### PR TITLE
Workaround Rails failure to properly require logger prior to Rails 7.1

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,13 +1,26 @@
+# bug in Rails pre-7.0 does not require 'logger' when it should....
+# concurrent-ruby prior to 1.3.5 masked the problem, and the easiest
+# way for us to get CI to work for such Rails is to use an older concurrent-ruby
+# version, other attempts to workaround were not succesful.
+#
+#
+# Rails will not be releasing a fix for Rails prior to 7.1.0
+# to release a fix. https://github.com/rails/rails/pull/54264
+#
+
 appraise "rails-60" do
   gem "rails", "~> 6.0.0"
+  gem "concurrent-ruby", "< 1.3.5"
 end
 
 appraise "rails-61" do
   gem "rails", "~> 6.1.0"
+  gem "concurrent-ruby", "< 1.3.5"
 end
 
 appraise "rails-70" do
   gem "rails", "~> 7.0.0"
+  gem "concurrent-ruby", "< 1.3.5"
 end
 
 appraise "rails-71" do

--- a/gemfiles/rails_60.gemfile
+++ b/gemfiles/rails_60.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.0.0"
+gem "concurrent-ruby", "< 1.3.5"
 
 group :development, :test do
   gem "rspec-rails", ">= 5.0", "< 7"

--- a/gemfiles/rails_61.gemfile
+++ b/gemfiles/rails_61.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.1.0"
+gem "concurrent-ruby", "< 1.3.5"
 
 group :development, :test do
   gem "rspec-rails", ">= 5.0", "< 7"

--- a/gemfiles/rails_70.gemfile
+++ b/gemfiles/rails_70.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.0.0"
+gem "concurrent-ruby", "< 1.3.5"
 
 group :development, :test do
   gem "rspec-rails", ">= 5.0", "< 7"


### PR DESCRIPTION
By using old version of concurrent-ruby that require'd logger itself and masked bug. Tried to workaround in other ways like adding 'logger' explicitly to gemfile or gemspec, but had a lot of mysterious trouble getting that to work.

See https://github.com/rails/rails/pull/54264
