### PR TITLE
define_derivative blocks can add metadata to be stored with derivative

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,10 @@
 
 * Kithe derivatves store created at in shrine metadata for derivative, as UTC iso8601 string https://github.com/sciencehistory/kithe/pull/190
 
+* `Attacher.define_derivative` block can now take an optional `add_metadata` keyword arg with a hash that can be mutated to set metadata on derivative. https://github.com/sciencehistory/kithe/pull/193  https://github.com/sciencehistory/kithe/blob/master/guides/derivatives.md#specifying-metadata-for-defined-derivatives
+
+* Built-in derivative transformers will supply some creation tooling metadata if given the `add_metadata` argument. If you are using these, you might have to change the signatures on your `define_derivative` calls to take advantage of new functionality. https://github.com/sciencehistory/kithe/pull/193  https://github.com/sciencehistory/kithe/blob/master/guides/derivatives.md#kithe-provided-derivative-creation-tools
+
 ### Fixed
 
 * Use up-to-date vips CLI thumbnail recommendations, without deprecated options Should be no change to thumbnails generated, just differnet form of args. https://github.com/sciencehistory/kithe/pull/192  https://github.com/sciencehistory/kithe/pull/194

--- a/app/derivative_transformers/kithe/ffmpeg_extract_jpg.rb
+++ b/app/derivative_transformers/kithe/ffmpeg_extract_jpg.rb
@@ -50,16 +50,16 @@ module Kithe
     def call(input_arg, add_metadata:nil)
       if input_arg.kind_of?(Shrine::UploadedFile)
         if input_arg.respond_to?(:url) && input_arg.url&.start_with?(/https?\:/)
-          _call(input_arg.url, add_metadata:)
+          _call(input_arg.url, add_metadata: add_metadata)
         else
           Shrine.with_file(input_arg) do |local_file|
-            _call(local_file.path, add_metadata:)
+            _call(local_file.path, add_metadata: add_metadata)
           end
         end
       elsif input_arg.respond_to?(:path)
-        _call(input_arg.path, add_metadata:)
+        _call(input_arg.path, add_metadata: add_metadata)
       else
-        _call(input_arg.to_s, add_metadata:)
+        _call(input_arg.to_s, add_metadata: add_metadata)
       end
     end
 

--- a/app/derivative_transformers/kithe/vips_cli_image_to_jpeg.rb
+++ b/app/derivative_transformers/kithe/vips_cli_image_to_jpeg.rb
@@ -19,7 +19,7 @@ module Kithe
   # built for use with kithe derivatives transformations, eg:
   #
   #     class Asset < KitheAsset
-  #       define_derivative(thumb) do |original_file, add_metadata:|
+  #       Attacher.define_derivative(:thumb) do |original_file, add_metadata:|
   #         Kithe::VipsCliImageToJpeg.new(max_width: 100, thumbnail_mode: true).call(original_file, add_metadata: add_metadata)
   #       end
   #     end

--- a/app/models/kithe/asset/derivative_definition.rb
+++ b/app/models/kithe/asset/derivative_definition.rb
@@ -9,12 +9,32 @@ class Kithe::Asset::DerivativeDefinition
     @proc = proc
   end
 
+  # @return [Hash] add_metadata hash of metadata to add to derivative on storage
   def call(original_file:,attacher:)
+    add_metadata = {}
+    kwargs = {}
+
     if proc_accepts_keyword?(:attacher)
-      proc.call(original_file, attacher: attacher)
+      kwargs[:attacher] = attacher
+    end
+
+    if proc_accepts_keyword?(:add_metadata)
+      kwargs[:add_metadata] = add_metadata
+    end
+
+    return_val = if kwargs.present?
+      proc.call(original_file, **kwargs)
     else
       proc.call(original_file)
     end
+
+    # Save in context to later write to actual stored derivative metadata
+    if add_metadata.present?
+      attacher.context[:add_metadata] ||= {}
+      attacher.context[:add_metadata][key] = add_metadata
+    end
+
+    return_val
   end
 
   # Do content-type restrictions defined for this definition match a given asset?

--- a/guides/derivatives.md
+++ b/guides/derivatives.md
@@ -163,7 +163,7 @@ However, to take advantage of this feature, avoiding a download, you'd have to w
 complex code. Same if you want to produce multiple resolution thumbnails. This isn't yet fully documented, but be aware of the existence of this service.
 
 ```ruby
-image_tmp_file = Kithe::FfmpegExtractJpg.new(start_seconds: start_seconds).call(original)
+image_tmp_file = Kithe::FfmpegExtractJpg.new(start_seconds: start_seconds).call(original, add_metadata: add_metadata)
 ```
 
 ## Manually triggering creaton of derivatives from definitions

--- a/guides/derivatives.md
+++ b/guides/derivatives.md
@@ -138,18 +138,18 @@ Which creates audio files from any audio file original, using a shell out to the
 
 ```ruby
 # Create a stereo 128k mp3 derivative. output_suffix is the only mandatory argument.
-define_derivative('mp3', content_type: "audio") do |original_file|
-  Kithe::FfmpegTransformer.new(bitrate: '128k', output_suffix: 'mp3').call(original_file)
+define_derivative('mp3', content_type: "audio") do |original_file, add_metadata:|
+  Kithe::FfmpegTransformer.new(bitrate: '128k', output_suffix: 'mp3').call(original_file, add_metadata: add_metadata)
 end
 
 # A mono webm file at only 64k:
-define_derivative('webm', content_type: "audio") do |original_file|
-  Kithe::FfmpegTransformer.new(bitrate: '64k', force_mono: true, output_suffix: 'webm').call(original_file)
+define_derivative('webm', content_type: "audio") do |original_file, add_metadata:|
+  Kithe::FfmpegTransformer.new(bitrate: '64k', force_mono: true, output_suffix: 'webm').call(original_file, add_metadata: add_metadata)
 end
 
 # libopus is used by default for webm conversions, but you could specify another codec:
-define_derivative('webm', content_type: "audio") do |original_file|
-  Kithe::FfmpegTransformer.new(output_suffix: 'webm', audio_codec: 'libopencore-amrwb').call(original_file)
+define_derivative('webm', content_type: "audio") do |original_file, add_metadata:|
+  Kithe::FfmpegTransformer.new(output_suffix: 'webm', audio_codec: 'libopencore-amrwb').call(original_file, add_metadata: add_metadata)
 end
 ```
 

--- a/guides/derivatives.md
+++ b/guides/derivatives.md
@@ -29,18 +29,6 @@ The `original_file` block parameter is a ruby `File` object, which is already op
 
 The object returned does not need to be a `File` object, it can be any [IO or IO-like](https://github.com/shrinerb/shrine#io-abstraction) object. If you return a ruby `File` or `Tempfile` object, kithe will take care of cleaning the file up from the local file system. You are responsible for cleaning up any intermediate files, ruby stdlib [Tempfile](https://docs.ruby-lang.org/en/2.5.0/Tempfile.html) and [Dir.mktmpdir](https://docs.ruby-lang.org/en/2.5.0/Dir.html#method-c-mktmpdir) may be useful.
 
-You can also optionally provide an `add_metadata` keyword arg to your block. It will be given a mutable hash that you can mutate to specify JSON-compatible metadata that will be stored with the derivative.
-
-```ruby
-class MyAssetUploader < Kithe::AssetUploader
-  Attacher.define_derivative(:thumb_small) do |original_file, add_metadata:|
-    add_metadata[:my_key] = "my value"
-
-    anything_that_returns_io_like_object(original_file)
-  end
-end
-```
-
 The kithe derivative definition functionality comes from a kithe plugin to shrine, [kithe_derivative_definitions](../lib/shrine/plugins/kithe_derivative_definitions.rb).
 
 These kithe derivative definitions will be created by a registered standard shrine derivatives processor with key `kithe_derivatives`, and could be addressed as such with standard shrine functionality:
@@ -115,6 +103,19 @@ class Asset < Kithe::Asset
 end
 ```
 
+### Specifying metadata for defined derivatives
+
+You can also optionally provide an `add_metadata` keyword arg to your block. It will be given a mutable hash that you can mutate to specify JSON-compatible metadata that will be stored with the derivative.
+
+```ruby
+class MyAssetUploader < Kithe::AssetUploader
+  Attacher.define_derivative(:thumb_small) do |original_file, add_metadata:|
+    add_metadata[:my_key] = "my value"
+
+    anything_that_returns_io_like_object(original_file)
+  end
+end
+```
 
 ### Kithe-provided derivative-creation tools
 

--- a/guides/derivatives.md
+++ b/guides/derivatives.md
@@ -115,8 +115,8 @@ Which can create a resized JPG from an image input, using a shell out to the `vi
 
 ```ruby
 class Asset < Kithe::Asset
-  define_derivative(:download_small) do |original_file|
-    Kithe::VipsCliImageToJpeg.new(max_width: 500).call(original_file)
+  define_derivative(:download_small) do |original_file, add_metadata:|
+    Kithe::VipsCliImageToJpeg.new(max_width: 500).call(original_file, add_metadata: add_metadata)
   end
 end
 ```
@@ -125,8 +125,8 @@ If you pass `thumbnail_mode: true` when instantiating Kithe::VipsCliImageToJpeg,
 
 ```ruby
 class Asset < Kithe::Asset
-  define_derivative(:thumb_small, content_type: "image") do |original_file|
-    Kithe::VipsCliImageToJpeg.new(max_width: 500, thumbnail_mode: true).call(original_file)
+  define_derivative(:thumb_small, content_type: "image") do |original_file, add_metadata:|
+    Kithe::VipsCliImageToJpeg.new(max_width: 500, thumbnail_mode: true).call(original_file, add_metadata: add_metadata)
   end
 end
 ```

--- a/guides/derivatives.md
+++ b/guides/derivatives.md
@@ -29,6 +29,18 @@ The `original_file` block parameter is a ruby `File` object, which is already op
 
 The object returned does not need to be a `File` object, it can be any [IO or IO-like](https://github.com/shrinerb/shrine#io-abstraction) object. If you return a ruby `File` or `Tempfile` object, kithe will take care of cleaning the file up from the local file system. You are responsible for cleaning up any intermediate files, ruby stdlib [Tempfile](https://docs.ruby-lang.org/en/2.5.0/Tempfile.html) and [Dir.mktmpdir](https://docs.ruby-lang.org/en/2.5.0/Dir.html#method-c-mktmpdir) may be useful.
 
+You can also optionally provide an `add_metadata` keyword arg to your block. It will be given a mutable hash that you can mutate to specify JSON-compatible metadata that will be stored with the derivative.
+
+```ruby
+class MyAssetUploader < Kithe::AssetUploader
+  Attacher.define_derivative(:thumb_small) do |original_file, add_metadata:|
+    add_metadata[:my_key] = "my value"
+
+    anything_that_returns_io_like_object(original_file)
+  end
+end
+```
+
 The kithe derivative definition functionality comes from a kithe plugin to shrine, [kithe_derivative_definitions](../lib/shrine/plugins/kithe_derivative_definitions.rb).
 
 These kithe derivative definitions will be created by a registered standard shrine derivatives processor with key `kithe_derivatives`, and could be addressed as such with standard shrine functionality:

--- a/spec/derivative_transformers/ffmpeg_extract_jpg_spec.rb
+++ b/spec/derivative_transformers/ffmpeg_extract_jpg_spec.rb
@@ -20,6 +20,16 @@ describe Kithe::FfmpegExtractJpg do
       expect(result).to be_kind_of(Tempfile)
       expect(Marcel::MimeType.for(StringIO.new(result.read))).to eq "image/jpeg"
     end
+
+    it "sets add_metadata" do
+      add_metadata = {}
+
+      extractor = Kithe::FfmpegExtractJpg.new(frame_sample_size: 300)
+      extractor.call(video_path, add_metadata: add_metadata)
+
+      expect(add_metadata[:ffmpeg_version]).to match /\d+\.\d+/
+      expect(add_metadata[:ffmpeg_command]).to match /ffmpeg -y -i .*\.jpg/
+    end
   end
 
   describe "from File" do
@@ -31,6 +41,15 @@ describe Kithe::FfmpegExtractJpg do
       expect(result).to be_present
       expect(result).to be_kind_of(Tempfile)
       expect(Marcel::MimeType.for(StringIO.new(result.read))).to eq "image/jpeg"
+    end
+
+    it "sets add_metadata" do
+      add_metadata = {}
+
+      Kithe::FfmpegExtractJpg.new.call(video_file, add_metadata: add_metadata)
+
+      expect(add_metadata[:ffmpeg_version]).to match /\d+\.\d+/
+      expect(add_metadata[:ffmpeg_command]).to match /ffmpeg -y -i .*\.jpg/
     end
   end
 
@@ -51,6 +70,15 @@ describe Kithe::FfmpegExtractJpg do
       expect(result).to be_present
       expect(result).to be_kind_of(Tempfile)
       expect(Marcel::MimeType.for(StringIO.new(result.read))).to eq "image/jpeg"
+    end
+
+    it "sets add_metadata" do
+      add_metadata = {}
+
+      Kithe::FfmpegExtractJpg.new.call(uploaded_file_obj, add_metadata: add_metadata)
+
+      expect(add_metadata[:ffmpeg_version]).to match /\d+\.\d+/
+      expect(add_metadata[:ffmpeg_command]).to match /ffmpeg -y -i .*\.jpg/
     end
   end
 
@@ -80,6 +108,19 @@ describe Kithe::FfmpegExtractJpg do
 
       result = Kithe::FfmpegExtractJpg.new.call(uploaded_file_obj)
     end
+
+    it "sets add_metadata" do
+      add_metadata = {}
+
+      expect_any_instance_of(TTY::Command).to receive(:run) do |instance, *args|
+        expect(args[0..3]).to eq ["ffmpeg", "-y", "-i", url]
+      end
+
+      Kithe::FfmpegExtractJpg.new.call(uploaded_file_obj, add_metadata: add_metadata)
+
+      expect(add_metadata[:ffmpeg_version]).to match /\d+\.\d+/
+      expect(add_metadata[:ffmpeg_command]).to match /ffmpeg -y -i .*\.jpg/
+    end
   end
 
 
@@ -94,6 +135,19 @@ describe Kithe::FfmpegExtractJpg do
       end
 
       result = Kithe::FfmpegExtractJpg.new.call(url)
+    end
+
+    it "sets add_metadata" do
+      add_metadata = {}
+
+      expect_any_instance_of(TTY::Command).to receive(:run) do |instance, *args|
+        expect(args[0..3]).to eq ["ffmpeg", "-y", "-i", url]
+      end
+
+      Kithe::FfmpegExtractJpg.new.call(url, add_metadata: add_metadata)
+
+      expect(add_metadata[:ffmpeg_version]).to match /\d+\.\d+/
+      expect(add_metadata[:ffmpeg_command]).to match /ffmpeg -y -i .*\.jpg/
     end
   end
 end

--- a/spec/derivative_transformers/ffmpeg_transformer_spec.rb
+++ b/spec/derivative_transformers/ffmpeg_transformer_spec.rb
@@ -85,4 +85,16 @@ describe Kithe::FfmpegTransformer do
       output.close!
     end
   end
+
+  describe "ffmpeg command metadata" do
+    it "is provided when arg is given" do
+      add_metadata = {}
+
+      instance = described_class.new(output_suffix: 'mp3', force_mono: true, bitrate: '32k')
+      output = instance.call(input_file, add_metadata: add_metadata)
+
+      expect(add_metadata[:ffmpeg_version]).to match /\d+\.\d+/
+      expect(add_metadata[:ffmpeg_command]).to match /ffmpeg -y -i .*\.mp3/
+    end
+  end
 end

--- a/spec/derivative_transformers/vips_cli_image_to_jpeg_spec.rb
+++ b/spec/derivative_transformers/vips_cli_image_to_jpeg_spec.rb
@@ -26,6 +26,16 @@ describe Kithe::VipsCliImageToJpeg do
 
         output.close!
       end
+
+      describe "with add_metadata" do
+        it "adds metadata" do
+          add_metadata = {}
+
+          Kithe::VipsCliImageToJpeg.new(thumbnail_mode: true, max_width: width).call(input_file, add_metadata: add_metadata)
+          expect(add_metadata[:vips_version]).to match /\d+\.\d+\.\d+/
+          expect(add_metadata[:vips_command]).to match /vipsthumbnail .*\.jpg\[Q=85,interlace,optimize_coding,keep=none\]/
+        end
+      end
     end
   end
 
@@ -53,6 +63,17 @@ describe Kithe::VipsCliImageToJpeg do
 
         output.close!
       end
+
+      describe "with add_metadata" do
+        it "adds metadata" do
+          add_metadata = {}
+
+          Kithe::VipsCliImageToJpeg.new(thumbnail_mode: false, max_width: width).call(input_file, add_metadata: add_metadata)
+          expect(add_metadata[:vips_version]).to match /\d+\.\d+\.\d+/
+          expect(add_metadata[:vips_command]).to match /vipsthumbnail .*\.jpg\[Q=85,interlace,optimize_coding\]/
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
And our built-in derivative transformers can supply such metadata, to record command line tool versions and args. 

- define_derivative block can take hash to specify add_metadata
- VipsCliImageToJpeg can add_metadata to derivatives with vips version and arguments used
- FfmpegTransformer can add metadata with ffmpeg command info
- FfmpegExtractJpg can provide metadata relevant to created derivative, ffmpeg version and args
- doc add_metadata for define_derivative
