### PR TITLE
More fixing of args for current vips thumbnail best practices

### DIFF
--- a/app/derivative_transformers/kithe/vips_cli_image_to_jpeg.rb
+++ b/app/derivative_transformers/kithe/vips_cli_image_to_jpeg.rb
@@ -90,7 +90,7 @@ module Kithe
     def maybe_profile_normalization_args
       return [] unless thumbnail_mode?
 
-      ["--export-profile", srgb_profile_path, "--delete"]
+      ["--export-profile", srgb_profile_path]
     end
 
     # Params to add on to end of JPG output path, as in:

--- a/app/derivative_transformers/kithe/vips_cli_image_to_jpeg.rb
+++ b/app/derivative_transformers/kithe/vips_cli_image_to_jpeg.rb
@@ -31,7 +31,8 @@ module Kithe
   #
   # Some usage suggestions at https://www.libvips.org/API/current/Using-vipsthumbnail.html
   class VipsCliImageToJpeg
-    class_attribute :srgb_profile_path, default: Kithe::Engine.root.join("lib", "vendor", "icc", "sRGB2014.icc").to_s
+    # vips has a built-in srgb profile, don't need our own anymore.
+    #class_attribute :srgb_profile_path, default: Kithe::Engine.root.join("lib", "vendor", "icc", "sRGB2014.icc").to_s
     class_attribute :vips_thumbnail_command, default: "vipsthumbnail"
     class_attribute :vips_command, default: "vips"
 
@@ -90,7 +91,7 @@ module Kithe
     def maybe_profile_normalization_args
       return [] unless thumbnail_mode?
 
-      ["--export-profile", srgb_profile_path]
+      ["--export-profile", "srgb"]
     end
 
     # Params to add on to end of JPG output path, as in:


### PR DESCRIPTION
See also #192, we forgot some

- vips no longer recommends --delete arg for thumbnails not sure what it does, i think our keep=none in jpg writer should be plenty
- vips provides it's own srgb profile built-in now, we don't need to bring our own
