### PR TITLE
add a mixin concern Kithe::BatchIndexableAroundAction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,14 @@
 
 *
 
+## 2.19.0
+
+### Added
+
+* Kithe::BatchIndexableAroundAction mixin concern, mainly so around_filter can
+live in gem source, and stay out of Rails "application trace". https://github.com/sciencehistory/kithe/pull/196
+
+
 ## 2.18.0
 
 * Rails 8.1 allowed by gemspec and tested, no logic changes.

--- a/app/controllers/concerns/kithe/batch_indexable_around_action.rb
+++ b/app/controllers/concerns/kithe/batch_indexable_around_action.rb
@@ -1,0 +1,34 @@
+module Kithe
+  # Can be included in a controller, or usually in ApplicationController for your
+  # whole app, to batch solr indexing that takes place in a controller action, into
+  # a single or fewer solr index commands.
+  #
+  # We used to just have implementers write this simple code in thier local app, which
+  # works fine, but you wind up with the around filter in all your stack traces, since
+  # it's around every action.
+  #
+  # So instead, just
+  #
+  #     include Kithe::BatchIndexableAroundAction
+  #
+  # in eg ApplicationController
+  #
+  module BatchIndexableAroundAction
+    extend ActiveSupport::Concern
+
+    included do
+      around_action :_kithe_batch_indexable_around_action
+    end
+
+    # Used as a Rails controller around_action to batch any kithe indexing directives
+    # in a controller action.
+    #
+    # As `index_with(batching: true)` only creates a Traject::Writer lazily on demand,
+    # this should not add appreciable overhead to actions that don't end up triggering any Solr updates.
+    def _kithe_batch_indexable_around_action
+      Kithe::Indexable.index_with(batching: true) do
+        yield
+      end
+    end
+  end
+end

--- a/guides/solr_indexing.md
+++ b/guides/solr_indexing.md
@@ -122,18 +122,14 @@ Would you like to have every controller in your app batch solr index updates wit
 
 ```ruby
 class ApplicationController < ActionController::Base
-  around_action :batch_kithe_indexable
+  include Kithe::BatchIndexableAroundAction
 
-  def batch_kithe_indexable
-    Kithe::Indexable.index_with(batching: true) do
-      yield
-    end
-  end
+  #...
+end
 ```
 
-As `index_with(batching: true)` only creates a Traject::Writer lazily on demand, this should not add appreciable overhead to actions that don't end up triggering any Solr updates.
-
-
+This will add an around_action to all your actions that uses `Kithe::Indexable.index_with(batching: true)` to batch multiple solr index updates that take place within a Rails action
+into fewer Solr updates.
 
 ## Disabling automatic callbacks
 

--- a/lib/kithe/version.rb
+++ b/lib/kithe/version.rb
@@ -1,3 +1,3 @@
 module Kithe
-  VERSION = '2.18.0'
+  VERSION = '2.19.0'
 end


### PR DESCRIPTION
Replace instructions to do it manually. 

the main advantage of this is just to avoid the around filter being in your stack trace on error reports for every error in any action, which is annoying. 

By moving the code to be inside kithe gem, Rails will automatically consider it outside the 'application' trace, and instead part of 'framework' or 'all' trace or something. 

See https://github.com/sciencehistory/scihist_digicoll/issues/3122
